### PR TITLE
Docker toolchain

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ hlua = "0.4.1"
 aabb-quadtree = "0.1.0"
 zstd = "0.4.14"
 stopwatch = "0.0.7"
-atomic = {version = "0.4", features = ["nightly"]}
+atomic = {version = "= 0.4.0", features = ["nightly"]}
 
 [features]
 enable-runtime-benchmarking = []

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,25 @@ examples:
 bench:
 	cargo build --examples --release --target=armv7-unknown-linux-gnueabihf --features "enable-runtime-benchmarking"
 
+.PHONY: docker-env
+docker-env:
+	cd docker-toolchain && docker build \
+		--build-arg UNAME=builder \
+		--build-arg UID=$(shell id -u) \
+		--build-arg GID=$(shell id -g) \
+		--tag rust-build-remarkable:latest .
+
+examples-docker: docker-env
+	docker volume create cargo-registry
+	docker run \
+		--rm \
+		--user builder \
+		-v $(shell pwd):/home/builder/libremarkable:rw \
+		-v cargo-registry:/home/builder/.cargo/registry \
+		-w /home/builder/libremarkable \
+		rust-build-remarkable:latest \
+		cargo build --examples --release --target=armv7-unknown-linux-gnueabihf
+
 library:
 	cargo build --release --target=armv7-unknown-linux-gnueabihf
 
@@ -15,10 +34,14 @@ test:
 	cargo test
 
 DEVICE_IP ?= "10.11.99.1"
-run: examples
+deploy-demo:
 	ssh root@$(DEVICE_IP) 'kill -9 `pidof demo` || true; systemctl stop xochitl || true'
 	scp ./target/armv7-unknown-linux-gnueabihf/release/examples/demo root@$(DEVICE_IP):~/
 	ssh root@$(DEVICE_IP) './demo'
+
+run: examples deploy-demo
+
+run-docker: examples-docker deploy-demo
 
 live: examples
 	ssh root@$(DEVICE_IP) 'kill -9 `pidof live` || true'

--- a/docker-toolchain/.cargo/config
+++ b/docker-toolchain/.cargo/config
@@ -1,0 +1,2 @@
+[target.armv7-unknown-linux-gnueabihf]
+linker = "arm-linux-gnueabihf-gcc"

--- a/docker-toolchain/Dockerfile
+++ b/docker-toolchain/Dockerfile
@@ -14,11 +14,8 @@ RUN groupadd -g $GID $UNAME
 RUN useradd -u $UID -g $GID -m $UNAME
 USER $UNAME
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain nightly -y
 ENV PATH="${PATH}:/home/$UNAME/.cargo/bin"
-
-RUN rustup install nightly
-RUN rustup default nightly
 
 RUN rustup target add armv7-unknown-linux-gnueabihf
 

--- a/docker-toolchain/Dockerfile
+++ b/docker-toolchain/Dockerfile
@@ -1,0 +1,28 @@
+FROM ubuntu:16.04
+LABEL maintainer='Charlton Rodda'
+
+# Need to specify UID and GID so they match the external user.
+# UNAME has no significance.
+ARG UNAME=builder
+ARG UID=1000
+ARG GID=1000
+
+RUN apt-get -qq update
+RUN apt-get -qq install curl build-essential gcc-arm-linux-gnueabihf vim
+
+RUN groupadd -g $GID $UNAME
+RUN useradd -u $UID -g $GID -m $UNAME
+USER $UNAME
+
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+ENV PATH="${PATH}:/home/$UNAME/.cargo/bin"
+
+RUN rustup install nightly
+RUN rustup default nightly
+
+RUN rustup target add armv7-unknown-linux-gnueabihf
+
+# make the registry folder to ensure correct permissions
+RUN mkdir -p "/home/$UNAME/.cargo/registry"
+
+ADD ./.cargo/config /home/$UNAME/.cargo/config

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(integer_atomics)]
-#![feature(const_size_of)]
 #![feature(box_syntax)]
 #![feature(nll)]
 


### PR DESCRIPTION
This PR adds a docker image specification that can be used to build rust binaries for the reMarkable. It works on Linux (untested on OS X) and only requires Docker and make as dependencies.

Before this PR, a user compiling on ubuntu 16.04 would need to perform all the steps listed [here](https://github.com/canselcik/libremarkable/issues/5#issuecomment-377592830) except for starting a VM. On 18.04, I was unable to cross compile successfully at all due to glibc versioning, despite much effort. However, with this PR merged, any linux user with docker, make and reMarkable ssh set up can do:
```
git clone https://github.com/canselcik/libremarkable
cd libremarkable
make run-docker
```
and see the demo running on their device. They can also copy the make target for compiling their own programs.

To make it easier to build in docker and deploy directly, the `run` target is now an alias for `examples` and `deploy-demo`. There is a new target, `run-docker`, which builds the binary in docker instead of locally before deploying. This pattern can be applied to other deployment targets if desired.

It also makes two changes that were needed for a successful build on latest nightly: pinning `atomic` to 0.4.0, and removing the `const_size_of` feature gate (as it appears to have been removed)

A couple technical notes:

- It's slower, but not that much.
    - The first build of the docker image and binary are expected to take some time. However, all three slow steps are cached:
        - The docker build is cached by docker, and should rarely change
        - The rust registry is mounted in a volume, and thus persisted across builds
        - The `target` folder is on the host, so the compiler cache is persisted across builds.
    - Some sample build times on my machine:
        - First build, no caches: `7m17.09s`
        - Build only changing `demo.rs`: `0m8.28s`
        - Build with no changes: `0m3.24s`
- Docker layer cache may cause the rust toolchain to go out of date. A couple potential workarounds:
    - periodically build the image with cache disabled to force a redownload
    - invalidate the cache by adding a file containing the date
- Mounting and using the directory without affecting permissions requires setting the UID and GID of the user inside the container to the owner of the directory. For now it is set to the UID and GID of the user running the make command, which should work in most cases. This also means the image is specific to the UID-GID combination, and can't easily be distributed. There are methods that solve that problem, like [what redis does](https://stackoverflow.com/a/29799703).