### PR TITLE
Do not create gid for OS X in Dockerfile.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ docker-env:
 		--build-arg UNAME=builder \
 		--build-arg UID=$(shell id -u) \
 		--build-arg GID=$(shell id -g) \
+		--build-arg ostype=${shell uname} \
 		--tag rust-build-remarkable:latest .
 
 examples-docker: docker-env

--- a/docker-toolchain/Dockerfile
+++ b/docker-toolchain/Dockerfile
@@ -6,11 +6,12 @@ LABEL maintainer='Charlton Rodda'
 ARG UNAME=builder
 ARG UID=1000
 ARG GID=1000
+ARG ostype=Linux
 
 RUN apt-get -qq update
 RUN apt-get -qq install curl build-essential gcc-arm-linux-gnueabihf vim
 
-RUN groupadd -g $GID $UNAME
+RUN bash -c 'if [ ${OSTYPE} == Linux ]; then groupadd -r --gid ${GID} ${UNAME}; fi'
 RUN useradd -u $UID -g $GID -m $UNAME
 USER $UNAME
 


### PR DESCRIPTION
Before merging please try on linux, in case i have missed anything.

Same issue as uber/pyro#700
It is mainly the solution applied in uber/pyro#719

Otherwise it fails on OS X

```bash
➜  libremarkable git:(docker-build-osx) git checkout master
Switched to branch 'master'
➜  libremarkable git:(master) make run-docker
cd docker-toolchain && docker build \
		--build-arg UNAME=builder \
		--build-arg UID=501 \
		--build-arg GID=20 \
		--tag rust-build-remarkable:latest .
Sending build context to Docker daemon  4.096kB
Step 1/15 : FROM ubuntu:16.04
 ---> b9e15a5d1e1a
Step 2/15 : LABEL maintainer='Charlton Rodda'
 ---> Using cache
 ---> 8cf9d3d46cdd
Step 3/15 : ARG UNAME=builder
 ---> Using cache
 ---> 2defc4c0ff5c
Step 4/15 : ARG UID=1000
 ---> Using cache
 ---> 069123eb928b
Step 5/15 : ARG GID=1000
 ---> Using cache
 ---> 237d2b20aca9
Step 6/15 : RUN apt-get -qq update
 ---> Using cache
 ---> 9e31320d7de2
Step 7/15 : RUN apt-get -qq install curl build-essential gcc-arm-linux-gnueabihf vim
 ---> Using cache
 ---> 08be37a45c4a
Step 8/15 : RUN groupadd -g $GID $UNAME
 ---> Running in 762da158af95
groupadd: GID '20' already exists
The command '/bin/sh -c groupadd -g $GID $UNAME' returned a non-zero code: 4
make: *** [docker-env] Error 4
```