### PR TITLE
Use cgmath for most coordinate representations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ aabb-quadtree = "0.1.0"
 zstd = "0.4.14"
 stopwatch = "0.0.7"
 atomic = {version = "= 0.4.0", features = ["nightly"]}
+cgmath = "0.16"
 
 [features]
 enable-runtime-benchmarking = []

--- a/examples/live.rs
+++ b/examples/live.rs
@@ -25,8 +25,8 @@ fn main() {
             continue;
         }
 
-        let rgb565 =
-            fb.dump_region(framebuffer::common::mxcfb_rect {
+        let rgb565 = fb
+            .dump_region(framebuffer::common::mxcfb_rect {
                 top: 0,
                 left: 0,
                 width: DISPLAYWIDTH as u32,
@@ -45,8 +45,7 @@ fn main() {
                 DISPLAYWIDTH.into(),
                 DISPLAYHEIGHT.into(),
                 image::ColorType::RGB(8),
-            )
-            .unwrap();
+            ).unwrap();
 
         let jpg = writer.into_inner().unwrap();
         let mut response = Response::new_empty(tiny_http::StatusCode(200))

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -6,14 +6,16 @@ pub mod storage;
 
 pub mod io;
 
+pub use cgmath;
+
 use image;
 pub trait FramebufferIO {
-    /// Writes an arbitrary length frame into the framebuffer
+    /// Writes an ausizerbitrary length frame into the framebuffer
     fn write_frame(&mut self, frame: &[u8]);
     /// Writes a single pixel at `(y, x)` with value `v`
-    fn write_pixel(&mut self, y: usize, x: usize, v: common::color);
+    fn write_pixel(&mut self, pos: cgmath::Point2<isize>, v: common::color);
     /// Reads the value of the pixel at `(y, x)`
-    fn read_pixel(&self, y: usize, x: usize) -> common::color;
+    fn read_pixel(&self, pos: cgmath::Point2<usize>) -> common::color;
     /// Reads the value at offset `ofst` from the mmapp'ed framebuffer region
     fn read_offset(&self, ofst: isize) -> u8;
     /// Dumps the contents of the specified rectangle into a `Vec<u8>` from which
@@ -30,65 +32,59 @@ pub trait FramebufferIO {
 
 pub mod draw;
 pub trait FramebufferDraw {
-    /// Draws `img` at y=top, x=left coordinates with 1:1 scaling
-    fn draw_image(&mut self, img: &image::RgbImage, top: usize, left: usize) -> common::mxcfb_rect;
+    /// Draws `img` at `pos` with 1:1 scaling
+    fn draw_image(&mut self, img: &image::RgbImage, pos: cgmath::Point2<i32>)
+        -> common::mxcfb_rect;
     /// Draws a straight line
     fn draw_line(
         &mut self,
-        y0: i32,
-        x0: i32,
-        y1: i32,
-        x1: i32,
-        width: usize,
+        start: cgmath::Point2<i32>,
+        end: cgmath::Point2<i32>,
+        width: u32,
         v: common::color,
     ) -> common::mxcfb_rect;
     /// Draws a circle using Bresenham circle algorithm
     fn draw_circle(
         &mut self,
-        y: usize,
-        x: usize,
-        rad: usize,
+        pos: cgmath::Point2<i32>,
+        rad: u32,
         c: common::color,
     ) -> common::mxcfb_rect;
     /// Fills a circle
     fn fill_circle(
         &mut self,
-        y: usize,
-        x: usize,
-        rad: usize,
+        pos: cgmath::Point2<i32>,
+        rad: u32,
         c: common::color,
     ) -> common::mxcfb_rect;
     /// Draws a bezier curve begining at `startpt`, with control point `ctrlpt`, ending at `endpt` with `color`
     fn draw_bezier(
         &mut self,
-        startpt: (f32, f32),
-        ctrlpt: (f32, f32),
-        endpt: (f32, f32),
-        width: usize,
+        startpt: cgmath::Point2<f32>,
+        ctrlpt: cgmath::Point2<f32>,
+        endpt: cgmath::Point2<f32>,
+        width: f32,
         v: common::color,
     ) -> common::mxcfb_rect;
-    /// Draws `text` at `(y, x)` with `color` using `scale`
+    /// Draws `text` at `pos` with `color` using scale `size`
     fn draw_text(
         &mut self,
-        y: usize,
-        x: usize,
+        pos: cgmath::Point2<f32>,
         text: String,
-        size: usize,
+        size: f32,
         col: common::color,
         dryrun: bool,
     ) -> common::mxcfb_rect;
-    /// Draws a 1px border rectangle of `height` and `width` at `(y, x)` with `border_px` border thickness
+    /// Draws a 1px border rectangle of size `size` at `pos` with `border_px` border thickness
     fn draw_rect(
         &mut self,
-        y: usize,
-        x: usize,
-        height: usize,
-        width: usize,
-        border_px: usize,
+        pos: cgmath::Point2<i32>,
+        size: cgmath::Vector2<u32>,
+        border_px: u32,
         c: common::color,
     );
-    /// Fills rectangle of `height` and `width` at `(y, x)`
-    fn fill_rect(&mut self, y: usize, x: usize, height: usize, width: usize, c: common::color);
+    /// Fills rectangle of size `size` at `pos`
+    fn fill_rect(&mut self, pos: cgmath::Point2<i32>, size: cgmath::Vector2<u32>, c: common::color);
     /// Clears the framebuffer however does not perform a refresh
     fn clear(&mut self);
 }

--- a/src/input/multitouch.rs
+++ b/src/input/multitouch.rs
@@ -1,3 +1,4 @@
+use framebuffer::cgmath;
 use framebuffer::common::{DISPLAYHEIGHT, DISPLAYWIDTH, MTHEIGHT, MTWIDTH};
 
 use evdev::raw::input_event;
@@ -36,8 +37,7 @@ pub enum MultitouchEvent {
     Touch {
         gesture_seq: u16,
         finger_id: u16,
-        y: u16,
-        x: u16,
+        position: cgmath::Point2<u16>,
     },
     Unknown,
 }
@@ -75,8 +75,7 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Option<InputE
                     let event = MultitouchEvent::Touch {
                         gesture_seq: state.last_touch_id.load(Ordering::Relaxed),
                         finger_id: state.last_finger_id.load(Ordering::Relaxed),
-                        y,
-                        x,
+                        position: cgmath::Point2 { x: x, y: y },
                     };
 
                     Some(InputEvent::MultitouchEvent { event })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,6 +49,7 @@ extern crate mmap;
 extern crate rusttype;
 extern crate zstd;
 
+pub extern crate cgmath;
 pub extern crate epoll;
 pub extern crate evdev;
 pub extern crate image;

--- a/src/ui_extensions/luaext.rs
+++ b/src/ui_extensions/luaext.rs
@@ -1,6 +1,7 @@
 use hlua;
 use std;
 
+use framebuffer::cgmath;
 use framebuffer::common::*;
 use framebuffer::core;
 
@@ -96,10 +97,12 @@ pub fn lua_draw_text(
         // TODO: Expose the drawn region to Lua so that it can be updated that's
         // returned from this draw_text function.
         framebuffer.draw_text(
-            ny as usize,
-            nx as usize,
+            cgmath::Point2 {
+                x: nx as f32,
+                y: ny as f32,
+            },
             stext,
-            nsize as usize,
+            nsize as f32,
             color::GRAY(ncolor as u8),
             false,
         );
@@ -114,7 +117,13 @@ pub fn lua_set_pixel(y: hlua::AnyLuaValue, x: hlua::AnyLuaValue, color: hlua::An
     ) = (y, x, color)
     {
         let framebuffer = get_current_framebuffer!();
-        framebuffer.write_pixel(ny as usize, nx as usize, color::GRAY(ncolor as u8));
+        framebuffer.write_pixel(
+            cgmath::Point2 {
+                x: nx as isize,
+                y: ny as isize,
+            },
+            color::GRAY(ncolor as u8),
+        );
     }
 }
 

--- a/tests/test_fb.rs
+++ b/tests/test_fb.rs
@@ -8,5 +8,3 @@ fn test_internal() {
     // TODO: Implement test skeleton
     assert_eq!(42, 42);
 }
-
-


### PR DESCRIPTION
This PR implements use of `cgmath` ([github](https://github.com/rustgd/cgmath), [docs](https://docs.rs/cgmath)) in most places in the library (including the API) where floats or field/argument pairs have previously been used. An overview of the changes:

- use `cgmath` for all API coordinates, except `mxcfb_rect` and hardware translation layers
- add some utility methods to `cgmath` and use them
- change some numerical types, in an attempt to improve consistency and ergonomics:
  - expose float arguments where it makes sense
  - allow negative offsets in position, as this allows things to be drawn with an off-screen position that overlaps onto the screen.
  - try to use the same number type width (e.g. u16 vs u32) in the same context unless there is an obvious reason not to
    - to be honest, I'm not sure what the reasoning is behind the existing type choices, but there's quite a variety. I'd like feedback on this; I'm happy to revert if necessary, but I think paring down the set of types in use (especially in the public API) further would be great if possible.
- fix a potential bug in a position comparison: the check `if rect.top != y as u32 && rect.left != x as u32` will fail if either coordinate is the same.
  - This unfortunately means that UI elements do a full redraw much more frequently, including the text for brush size. (The actual `min_y` value of the bounding box is lower than the `y` of the nominal position, but the `x` is the same for both.)
- use `.cast().unwrap()` for casting element types. It's not clear when this can fail, and there is an [outstanding issue](https://github.com/rust-num/num-traits/issues/9) for documenting the possible failure conditions. However, I haven't seen any errors in my testing. If any panics due to this _are_ encountered, in my opinion that cast should be fixed and the use of `.cast().unwrap()` should be re-evaluated.

There may still be inconsistencies that need resolving. Those are likely either an oversight on my part or a reluctance to change types without a clear understanding of the reasoning behind them.

This PR is not yet thoroughly tested, but I wanted to get it out there so any issues with approach could be identified early on. After that stage, I think a good way to test it practically would be to port an existing, larger application using `libremarkable` already and see how it goes.