### PR TITLE
Standardise on u32 and i32 instead of usize/isize where possible.

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -37,11 +37,11 @@ use std::time::Duration;
 
 #[derive(Copy, Clone, PartialEq)]
 enum DrawMode {
-    Draw(usize),
-    Erase(usize),
+    Draw(u32),
+    Erase(u32),
 }
 impl DrawMode {
-    fn set_size(self, new_size: usize) -> Self {
+    fn set_size(self, new_size: u32) -> Self {
         match self {
             DrawMode::Draw(_) => DrawMode::Draw(new_size),
             DrawMode::Erase(_) => DrawMode::Erase(new_size),
@@ -54,7 +54,7 @@ impl DrawMode {
         }
         .into()
     }
-    fn get_size(self) -> usize {
+    fn get_size(self) -> u32 {
         match self {
             DrawMode::Draw(s) => s,
             DrawMode::Erase(s) => s,
@@ -353,14 +353,14 @@ fn draw_color_test_rgb(app: &mut appctx::ApplicationContext, _element: UIElement
     );
 }
 
-fn change_brush_width(app: &mut appctx::ApplicationContext, delta: isize) {
+fn change_brush_width(app: &mut appctx::ApplicationContext, delta: i32) {
     let current = G_DRAW_MODE.load(Ordering::Relaxed);
-    let new_size = current.get_size() as isize + delta;
+    let new_size = current.get_size() as i32 + delta;
     if new_size < 1 || new_size > 99 {
         return;
     }
 
-    G_DRAW_MODE.store(current.set_size(new_size as usize), Ordering::Relaxed);
+    G_DRAW_MODE.store(current.set_size(new_size as u32), Ordering::Relaxed);
 
     let element = app.get_element_by_name("displaySize").unwrap();
     if let UIElement::Text { ref mut text, .. } = element.write().inner {

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -51,7 +51,8 @@ impl DrawMode {
         match self {
             DrawMode::Draw(_) => "Black",
             DrawMode::Erase(_) => "White",
-        }.into()
+        }
+        .into()
     }
     fn get_size(self) -> usize {
         match self {
@@ -80,7 +81,8 @@ impl TouchMode {
             TouchMode::OnlyUI => "None",
             TouchMode::Bezier => "Bezier",
             TouchMode::Circles => "Circles",
-        }.into()
+        }
+        .into()
     }
 }
 
@@ -137,8 +139,10 @@ fn on_zoom_out(app: &mut appctx::ApplicationContext, _element: UIElementHandle) 
                     CANVAS_REGION.width,
                     CANVAS_REGION.height,
                     buff.as_slice(),
-                ).unwrap(),
-            ).resize(
+                )
+                .unwrap(),
+            )
+            .resize(
                 (CANVAS_REGION.width as f32 / 1.25f32) as u32,
                 (CANVAS_REGION.height as f32 / 1.25f32) as u32,
                 image::imageops::Nearest,
@@ -181,8 +185,10 @@ fn on_blur_canvas(app: &mut appctx::ApplicationContext, _element: UIElementHandl
                     CANVAS_REGION.width,
                     CANVAS_REGION.height,
                     buff.as_slice(),
-                ).unwrap(),
-            ).blur(0.6f32);
+                )
+                .unwrap(),
+            )
+            .blur(0.6f32);
 
             framebuffer.draw_image(
                 &dynamic.as_rgb8().unwrap(),
@@ -608,7 +614,7 @@ fn main() {
             refresh: UIConstraintRefresh::Refresh,
 
             /* We could have alternatively done this:
-
+            
                // Create a clickable region for multitouch input and associate it with its handler fn
                app.create_active_region(10, 900, 240, 480, on_touch_rustlogo);
             */

--- a/examples/live.rs
+++ b/examples/live.rs
@@ -31,13 +31,15 @@ fn main() {
                 left: 0,
                 width: DISPLAYWIDTH as u32,
                 height: DISPLAYHEIGHT as u32,
-            }).unwrap();
+            })
+            .unwrap();
 
         let rgb888 = framebuffer::storage::rgbimage_from_u8_slice(
             DISPLAYWIDTH.into(),
             DISPLAYHEIGHT.into(),
             &rgb565,
-        ).unwrap();
+        )
+        .unwrap();
         let mut writer = BufWriter::new(Vec::new());
         image::jpeg::JPEGEncoder::new(&mut writer)
             .encode(
@@ -45,7 +47,8 @@ fn main() {
                 DISPLAYWIDTH.into(),
                 DISPLAYHEIGHT.into(),
                 image::ColorType::RGB(8),
-            ).unwrap();
+            )
+            .unwrap();
 
         let jpg = writer.into_inner().unwrap();
         let mut response = Response::new_empty(tiny_http::StatusCode(200))

--- a/src/appctx.rs
+++ b/src/appctx.rs
@@ -202,7 +202,7 @@ impl<'a> ApplicationContext<'a> {
         &mut self,
         position: cgmath::Point2<i32>,
         size: cgmath::Vector2<u32>,
-        border_px: usize,
+        border_px: u32,
         border_color: color,
         refresh: UIConstraintRefresh,
     ) -> mxcfb_rect {

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -73,7 +73,8 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
                 mmap::MapOption::MapOffset(0),
                 mmap::MapOption::MapNonStandardFlags(libc::MAP_SHARED),
             ],
-        ).unwrap();
+        )
+        .unwrap();
 
         // Load the font
         let font_data = include_bytes!("../../assets/Roboto-Regular.ttf");

--- a/src/framebuffer/draw.rs
+++ b/src/framebuffer/draw.rs
@@ -95,8 +95,8 @@ impl<'a> framebuffer::FramebufferDraw for core::Framebuffer<'a> {
             match width {
                 1 => self.write_pixel(
                     Point2 {
-                        x: x0 as isize,
-                        y: y0 as isize,
+                        x: x0 as i32,
+                        y: y0 as i32,
                     },
                     v,
                 ),
@@ -147,8 +147,8 @@ impl<'a> framebuffer::FramebufferDraw for core::Framebuffer<'a> {
         for (x, y) in line_drawing::BresenhamCircle::new(pos.x as i32, pos.y as i32, rad as i32) {
             self.write_pixel(
                 Point2 {
-                    x: x as isize,
-                    y: y as isize,
+                    x: x as i32,
+                    y: y as i32,
                 },
                 v,
             );
@@ -168,8 +168,8 @@ impl<'a> framebuffer::FramebufferDraw for core::Framebuffer<'a> {
             {
                 self.write_pixel(
                     Point2 {
-                        x: x as isize,
-                        y: y as isize,
+                        x: x as i32,
+                        y: y as i32,
                     },
                     v,
                 );
@@ -206,7 +206,7 @@ impl<'a> framebuffer::FramebufferDraw for core::Framebuffer<'a> {
                 1 => self.write_pixel(approx, v),
                 _ => self.fill_rect(
                     approx
-                        .sub_element_wise((width / 2.0) as isize)
+                        .sub_element_wise((width / 2.0) as i32)
                         .cast()
                         .unwrap(),
                     Vector2 {
@@ -278,8 +278,8 @@ impl<'a> framebuffer::FramebufferDraw for core::Framebuffer<'a> {
                     let mult = (1.0 - v).min(1.0);
                     self.write_pixel(
                         Point2 {
-                            x: (x + bounding_box.min.x as u32) as isize,
-                            y: (y + bounding_box.min.y as u32) as isize,
+                            x: (x + bounding_box.min.x as u32) as i32,
+                            y: (y + bounding_box.min.y as u32) as i32,
                         },
                         color::RGB((c1 * mult) as u8, (c2 * mult) as u8, (c3 * mult) as u8),
                     )
@@ -319,8 +319,8 @@ impl<'a> framebuffer::FramebufferDraw for core::Framebuffer<'a> {
             for xpos in pos.x..pos.x + size.x as i32 {
                 self.write_pixel(
                     Point2 {
-                        x: xpos as isize,
-                        y: ypos as isize,
+                        x: xpos as i32,
+                        y: ypos as i32,
                     },
                     c,
                 );

--- a/src/framebuffer/io.rs
+++ b/src/framebuffer/io.rs
@@ -14,7 +14,7 @@ impl<'a> framebuffer::FramebufferIO for framebuffer::core::Framebuffer<'a> {
     }
 
     #[inline]
-    fn write_pixel(&mut self, pos: cgmath::Point2<isize>, col: framebuffer::common::color) {
+    fn write_pixel(&mut self, pos: cgmath::Point2<i32>, col: framebuffer::common::color) {
         let w = self.var_screen_info.xres as usize;
         let h = self.var_screen_info.yres as usize;
         if pos.y < 0 || pos.x < 0 {
@@ -25,7 +25,7 @@ impl<'a> framebuffer::FramebufferIO for framebuffer::core::Framebuffer<'a> {
         }
         let line_length = self.fix_screen_info.line_length as isize;
         let bytespp = (self.var_screen_info.bits_per_pixel / 8) as isize;
-        let curr_index = pos.y * line_length + pos.x * bytespp;
+        let curr_index = pos.y as isize * line_length + pos.x as isize * bytespp;
 
         let begin = self.frame.data() as *mut u8;
         let components = col.as_native();
@@ -35,16 +35,16 @@ impl<'a> framebuffer::FramebufferIO for framebuffer::core::Framebuffer<'a> {
         }
     }
 
-    fn read_pixel(&self, pos: cgmath::Point2<usize>) -> framebuffer::common::color {
+    fn read_pixel(&self, pos: cgmath::Point2<u32>) -> framebuffer::common::color {
         let w = self.var_screen_info.xres as usize;
         let h = self.var_screen_info.yres as usize;
-        if pos.y >= h || pos.x >= w {
+        if pos.y as usize >= h || pos.x as usize >= w {
             error!("Attempting to read pixel out of range. Returning a white pixel.");
             return framebuffer::common::color::WHITE;
         }
         let line_length = self.fix_screen_info.line_length as usize;
         let bytespp = (self.var_screen_info.bits_per_pixel / 8) as usize;
-        let curr_index = pos.y * line_length + pos.x * bytespp;
+        let curr_index = pos.y as usize * line_length + pos.x as usize * bytespp;
 
         let begin = self.frame.data() as *mut u8;
         let (c1, c2) = unsafe {

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -10,12 +10,12 @@ pub use cgmath;
 
 use image;
 pub trait FramebufferIO {
-    /// Writes an ausizerbitrary length frame into the framebuffer
+    /// Writes an arbitrary length frame into the framebuffer
     fn write_frame(&mut self, frame: &[u8]);
     /// Writes a single pixel at `(y, x)` with value `v`
-    fn write_pixel(&mut self, pos: cgmath::Point2<isize>, v: common::color);
+    fn write_pixel(&mut self, pos: cgmath::Point2<i32>, v: common::color);
     /// Reads the value of the pixel at `(y, x)`
-    fn read_pixel(&self, pos: cgmath::Point2<usize>) -> common::color;
+    fn read_pixel(&self, pos: cgmath::Point2<u32>) -> common::color;
     /// Reads the value at offset `ofst` from the mmapp'ed framebuffer region
     fn read_offset(&self, ofst: isize) -> u8;
     /// Dumps the contents of the specified rectangle into a `Vec<u8>` from which

--- a/src/framebuffer/screeninfo.rs
+++ b/src/framebuffer/screeninfo.rs
@@ -48,7 +48,7 @@ pub struct VarScreeninfo {
 #[derive(Clone, Debug)]
 pub struct FixScreeninfo {
     pub id: [u8; 16],
-    pub smem_start: usize,
+    pub smem_start: u32,
     pub smem_len: u32,
     pub fb_type: u32,
     pub type_aux: u32,
@@ -57,7 +57,7 @@ pub struct FixScreeninfo {
     pub ypanstep: u16,
     pub ywrapstep: u16,
     pub line_length: u32,
-    pub mmio_start: usize,
+    pub mmio_start: u32,
     pub mmio_len: u32,
     pub accel: u32,
     pub capabilities: u16,

--- a/src/ui_extensions/element.rs
+++ b/src/ui_extensions/element.rs
@@ -45,7 +45,7 @@ pub struct UIElementHandle(Arc<RwLock<UIElementWrapper>>);
 
 #[derive(Clone)]
 pub struct UIElementWrapper {
-    pub position: cgmath::Point2<isize>,
+    pub position: cgmath::Point2<i32>,
     pub refresh: UIConstraintRefresh,
     pub last_drawn_rect: Option<common::mxcfb_rect>,
     pub onclick: Option<ActiveRegionFunction>,
@@ -85,15 +85,15 @@ pub enum UIElement {
         text: String,
         scale: f32,
         foreground: color,
-        border_px: usize,
+        border_px: u32,
     },
     Image {
         img: image::DynamicImage,
     },
     Region {
-        size: cgmath::Vector2<usize>,
+        size: cgmath::Vector2<u32>,
         border_color: color,
-        border_px: usize,
+        border_px: u32,
     },
     Unspecified,
 }

--- a/src/ui_extensions/luaext.rs
+++ b/src/ui_extensions/luaext.rs
@@ -119,8 +119,8 @@ pub fn lua_set_pixel(y: hlua::AnyLuaValue, x: hlua::AnyLuaValue, color: hlua::An
         let framebuffer = get_current_framebuffer!();
         framebuffer.write_pixel(
             cgmath::Point2 {
-                x: nx as isize,
-                y: ny as isize,
+                x: nx as i32,
+                y: ny as i32,
             },
             color::GRAY(ncolor as u8),
         );


### PR DESCRIPTION
This is a fairly find and replace change of all instances of isize/usize with i32/u32, except where we deal with memory directly. I discussed this possibility with @canselcik recently so I thought I'd put out a diff for further discussion.

There is exactly one place where I have left isize in the external API:

```
    /// Reads the value at offset `ofst` from the mmapp'ed framebuffer region
    fn read_offset(&self, ofst: isize) -> u8;
```

As this deals directly with a memory offset, I thought it best to leave it as is.

I also included a `cargo fmt`, but I can remove that if you prefer.