### PR TITLE
Graphics rendering improvements

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -561,7 +561,7 @@ fn on_touch_handler(app: &mut appctx::ApplicationContext, input: multitouch::Mul
                 m @ TouchMode::Diamonds | m @ TouchMode::FillDiamonds => {
                     let position_int = position.cast().unwrap();
                     framebuffer.draw_polygon(
-                        vec![
+                        &vec![
                             position_int + cgmath::vec2(-10, 0),
                             position_int + cgmath::vec2(0, 20),
                             position_int + cgmath::vec2(10, 0),

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -533,14 +533,28 @@ fn on_touch_handler(app: &mut appctx::ApplicationContext, input: multitouch::Mul
             let rect = match G_TOUCH_MODE.load(Ordering::Relaxed) {
                 TouchMode::Bezier => {
                     let position_float = position.cast().unwrap();
-                    framebuffer.draw_bezier(
-                        position_float,
-                        position_float + cgmath::vec2(155.0, 14.0),
-                        position_float + cgmath::vec2(200.0, 200.0),
-                        2.0,
-                        1000,
-                        color::BLACK,
-                    )
+                    let points = vec![
+                        (cgmath::vec2(-40.0, 0.0), 2.5),
+                        (cgmath::vec2(40.0, -60.0), 5.5),
+                        (cgmath::vec2(0.0, 0.0), 3.5),
+                        (cgmath::vec2(-40.0, 60.0), 6.5),
+                        (cgmath::vec2(-10.0, 50.0), 5.0),
+                        (cgmath::vec2(10.0, 45.0), 4.5),
+                        (cgmath::vec2(30.0, 55.0), 3.5),
+                        (cgmath::vec2(50.0, 65.0), 3.0),
+                        (cgmath::vec2(70.0, 40.0), 0.0),
+                    ];
+                    let mut rect = mxcfb_rect::invalid();
+                    for window in points.windows(3).step_by(2) {
+                        rect = rect.merge_rect(&framebuffer.draw_dynamic_bezier(
+                            (position_float + window[0].0, window[0].1),
+                            (position_float + window[1].0, window[1].1),
+                            (position_float + window[2].0, window[2].1),
+                            100,
+                            color::BLACK,
+                        ));
+                    }
+                    rect
                 }
                 TouchMode::Circles => {
                     framebuffer.draw_circle(position.cast().unwrap(), 20, color::BLACK)

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -463,10 +463,10 @@ fn on_wacom_input(app: &mut appctx::ApplicationContext, input: wacom::WacomEvent
                 let start_point = points[2].0.midpoint(points[1].0);
                 let ctrl_point = points[1].0;
                 let end_point = points[1].0.midpoint(points[0].0);
-                // calculate radii
-                let start_width = (radii[2] + radii[1]) / 2.0;
-                let ctrl_width = radii[1];
-                let end_width = (radii[1] + radii[0]) / 2.0;
+                // calculate diameters
+                let start_width = radii[2] + radii[1];
+                let ctrl_width = radii[1] * 2.0;
+                let end_width = radii[1] + radii[0];
                 let rect = framebuffer.draw_dynamic_bezier(
                     (start_point, start_width),
                     (ctrl_point, ctrl_width),

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -364,8 +364,16 @@ fn draw_color_test_rgb(app: &mut appctx::ApplicationContext, _element: UIElement
 
 fn change_brush_width(app: &mut appctx::ApplicationContext, delta: i32) {
     let current = G_DRAW_MODE.load(Ordering::Relaxed);
-    let new_size = current.get_size() as i32 + delta;
-    if new_size < 1 || new_size > 99 {
+    let current_size = current.get_size() as i32;
+    let proposed_size = current_size + delta;
+    let new_size = if proposed_size < 1 {
+        1
+    } else if proposed_size > 99 {
+        99
+    } else {
+        proposed_size
+    };
+    if new_size == current_size {
         return;
     }
 
@@ -857,9 +865,26 @@ fn main() {
 
     // Size Controls
     app.add_element(
-        "decreaseSize",
+        "decreaseSizeSkip",
         UIElementWrapper {
             position: cgmath::Point2 { x: 960, y: 670 },
+            refresh: UIConstraintRefresh::Refresh,
+            onclick: Some(|appctx, _| {
+                change_brush_width(appctx, -10);
+            }),
+            inner: UIElement::Text {
+                foreground: color::BLACK,
+                text: "--".to_owned(),
+                scale: 90.0,
+                border_px: 5,
+            },
+            ..Default::default()
+        },
+    );
+    app.add_element(
+        "decreaseSize",
+        UIElementWrapper {
+            position: cgmath::Point2 { x: 1030, y: 670 },
             refresh: UIConstraintRefresh::Refresh,
             onclick: Some(|appctx, _| {
                 change_brush_width(appctx, -1);
@@ -876,7 +901,7 @@ fn main() {
     app.add_element(
         "displaySize",
         UIElementWrapper {
-            position: cgmath::Point2 { x: 1030, y: 670 },
+            position: cgmath::Point2 { x: 1080, y: 670 },
             refresh: UIConstraintRefresh::Refresh,
             inner: UIElement::Text {
                 foreground: color::BLACK,
@@ -890,7 +915,7 @@ fn main() {
     app.add_element(
         "increaseSize",
         UIElementWrapper {
-            position: cgmath::Point2 { x: 1210, y: 670 },
+            position: cgmath::Point2 { x: 1240, y: 670 },
             refresh: UIConstraintRefresh::Refresh,
             onclick: Some(|appctx, _| {
                 change_brush_width(appctx, 1);
@@ -898,7 +923,24 @@ fn main() {
             inner: UIElement::Text {
                 foreground: color::BLACK,
                 text: "+".to_owned(),
-                scale: 90.0,
+                scale: 60.0,
+                border_px: 5,
+            },
+            ..Default::default()
+        },
+    );
+    app.add_element(
+        "increaseSizeSkip",
+        UIElementWrapper {
+            position: cgmath::Point2 { x: 1295, y: 670 },
+            refresh: UIConstraintRefresh::Refresh,
+            onclick: Some(|appctx, _| {
+                change_brush_width(appctx, 10);
+            }),
+            inner: UIElement::Text {
+                foreground: color::BLACK,
+                text: "++".to_owned(),
+                scale: 60.0,
                 border_px: 5,
             },
             ..Default::default()

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -40,21 +40,18 @@ use std::time::Duration;
 #[derive(Copy, Clone, PartialEq)]
 enum DrawMode {
     Draw(u32),
-    PolyDraw(u32),
     Erase(u32),
 }
 impl DrawMode {
     fn set_size(self, new_size: u32) -> Self {
         match self {
             DrawMode::Draw(_) => DrawMode::Draw(new_size),
-            DrawMode::PolyDraw(_) => DrawMode::PolyDraw(new_size),
             DrawMode::Erase(_) => DrawMode::Erase(new_size),
         }
     }
     fn color_as_string(self) -> String {
         match self {
             DrawMode::Draw(_) => "Black",
-            DrawMode::PolyDraw(_) => "Black (New)",
             DrawMode::Erase(_) => "White",
         }
         .into()
@@ -62,7 +59,6 @@ impl DrawMode {
     fn get_size(self) -> u32 {
         match self {
             DrawMode::Draw(s) => s,
-            DrawMode::PolyDraw(s) => s,
             DrawMode::Erase(s) => s,
         }
     }
@@ -319,8 +315,7 @@ fn on_touch_rustlogo(app: &mut appctx::ApplicationContext, _element: UIElementHa
 fn on_toggle_eraser(app: &mut appctx::ApplicationContext, _: UIElementHandle) {
     let (new_mode, name) = match G_DRAW_MODE.load(Ordering::Relaxed) {
         DrawMode::Erase(s) => (DrawMode::Draw(s), "Black".to_owned()),
-        DrawMode::Draw(s) => (DrawMode::PolyDraw(s), "Black (New)".to_owned()),
-        DrawMode::PolyDraw(s) => (DrawMode::Erase(s), "White".to_owned()),
+        DrawMode::Draw(s) => (DrawMode::Erase(s), "White".to_owned()),
     };
     G_DRAW_MODE.store(new_mode, Ordering::Relaxed);
 
@@ -438,54 +433,39 @@ fn on_wacom_input(app: &mut appctx::ApplicationContext, input: wacom::WacomEvent
                 return;
             }
 
-            let (col, mult, use_poly) = match G_DRAW_MODE.load(Ordering::Relaxed) {
-                DrawMode::Draw(s) => (color::BLACK, s, false),
-                DrawMode::PolyDraw(s) => (color::BLACK, s, true),
-                DrawMode::Erase(s) => (color::WHITE, s * 3, false),
+            let (col, mult) = match G_DRAW_MODE.load(Ordering::Relaxed) {
+                DrawMode::Draw(s) => (color::BLACK, s),
+                DrawMode::Erase(s) => (color::WHITE, s * 3),
             };
 
             wacom_stack.push_back((position.cast().unwrap(), pressure as i32));
 
             while wacom_stack.len() >= 3 {
                 let framebuffer = app.get_framebuffer_ref();
-                let rect = if use_poly {
-                    let points = vec![
-                        wacom_stack.pop_front().unwrap(),
-                        wacom_stack.get(0).unwrap().clone(),
-                        wacom_stack.get(1).unwrap().clone(),
-                    ];
-                    let radii: Vec<f32> = points
-                        .iter()
-                        .map(|point| ((mult as f32 * (point.1 as f32) / 2048.) / 2.0))
-                        .collect();
-                    // calculate control points
-                    let start_point = points[2].0.midpoint(points[1].0);
-                    let ctrl_point = points[1].0;
-                    let end_point = points[1].0.midpoint(points[0].0);
-                    // calculate radii
-                    let start_width = (radii[2] + radii[1]) / 2.0;
-                    let ctrl_width = radii[1];
-                    let end_width = (radii[1] + radii[0]) / 2.0;
-                    framebuffer.draw_dynamic_bezier(
-                        (start_point, start_width),
-                        (ctrl_point, ctrl_width),
-                        (end_point, end_width),
-                        10,
-                        col,
-                    )
-                } else {
-                    let beginpt = wacom_stack.pop_front().unwrap();
-                    let controlpt = wacom_stack.pop_front().unwrap();
-                    let endpt = wacom_stack.get(0).unwrap();
-                    let width = (mult as f32 * (controlpt.1 as f32) / 2048.) / 2.0;
-                    framebuffer.draw_dynamic_bezier(
-                        (beginpt.0, width),
-                        (controlpt.0, width),
-                        (endpt.0, width),
-                        10,
-                        col,
-                    )
-                };
+                let points = vec![
+                    wacom_stack.pop_front().unwrap(),
+                    wacom_stack.get(0).unwrap().clone(),
+                    wacom_stack.get(1).unwrap().clone(),
+                ];
+                let radii: Vec<f32> = points
+                    .iter()
+                    .map(|point| ((mult as f32 * (point.1 as f32) / 2048.) / 2.0))
+                    .collect();
+                // calculate control points
+                let start_point = points[2].0.midpoint(points[1].0);
+                let ctrl_point = points[1].0;
+                let end_point = points[1].0.midpoint(points[0].0);
+                // calculate radii
+                let start_width = (radii[2] + radii[1]) / 2.0;
+                let ctrl_width = radii[1];
+                let end_width = (radii[1] + radii[0]) / 2.0;
+                let rect = framebuffer.draw_dynamic_bezier(
+                    (start_point, start_width),
+                    (ctrl_point, ctrl_width),
+                    (end_point, end_width),
+                    10,
+                    col,
+                );
 
                 framebuffer.partial_refresh(
                     &rect,

--- a/src/framebuffer/graphics.rs
+++ b/src/framebuffer/graphics.rs
@@ -1,0 +1,375 @@
+use std;
+
+use framebuffer::cgmath::*;
+use framebuffer::common::*;
+
+macro_rules! min {
+        ($x: expr) => ($x);
+        ($x: expr, $($z: expr),+) => (::std::cmp::min($x, min!($($z),*)));
+}
+
+macro_rules! max {
+        ($x: expr) => ($x);
+        ($x: expr, $($z: expr),+) => (::std::cmp::max($x, max!($($z),*)));
+}
+
+pub fn stamp_along_line<F>(stamp: &mut F, start: Point2<i32>, end: Point2<i32>) -> mxcfb_rect
+where
+    F: FnMut(Point2<i32>),
+{
+    // Create local variables for moving start point
+    let mut x = start.x;
+    let mut y = start.y;
+
+    // Get absolute x/y offset
+    let dx = if start.x > end.x {
+        start.x - end.x
+    } else {
+        end.x - start.x
+    };
+    let dy = if start.y > end.y {
+        start.y - end.y
+    } else {
+        end.y - start.y
+    };
+
+    // Get slopes
+    let sx = if start.x < end.x { 1 } else { -1 };
+    let sy = if start.y < end.y { 1 } else { -1 };
+
+    // Initialize error
+    let mut err = if dx > dy { dx } else { -dy } / 2;
+    let mut err2;
+
+    let (mut min_x, mut max_x, mut min_y, mut max_y) = (x, x, y, y);
+    loop {
+        // Stamp point
+        stamp(Point2 { x, y });
+
+        max_y = max!(max_y, y);
+        min_y = min!(min_y, y);
+        min_x = min!(min_x, x);
+        max_x = max!(max_x, x);
+
+        // Check end condition
+        if x == end.x && y == end.y {
+            break;
+        };
+
+        // Store old error
+        err2 = 2 * err;
+
+        // Adjust error and start position
+        if err2 > -dx {
+            err -= dy;
+            x += sx;
+        }
+        if err2 < dy {
+            err += dx;
+            y += sy;
+        }
+    }
+
+    mxcfb_rect {
+        top: (min_y) as u32,
+        left: (min_x) as u32,
+        width: (max_x - min_x) as u32,
+        height: (max_y - min_y) as u32,
+    }
+}
+pub fn draw_polygon<F>(write_pixel: &mut F, points: Vec<Point2<i32>>, fill: bool) -> mxcfb_rect
+where
+    F: FnMut(Point2<i32>),
+{
+    // This implementation of polygon rasterisation is based on this article:
+    // https://hackernoon.com/computer-graphics-scan-line-polygon-fill-algorithm-3cb47283df6
+
+    // struct to hold edge data
+    #[derive(Debug, Copy, Clone)]
+    struct EdgeBucket {
+        ymax: i32,
+        ymin: i32,
+        x: i32,
+        sign: i32,
+        direction: i32,
+        dx: i32,
+        dy: i32,
+        sum: i32,
+    };
+
+    // initialise our edge table
+    let mut edge_table = Vec::new();
+    let num_edges = points.len();
+    for i in 0..num_edges {
+        let p0 = points[i];
+        let p1 = points[(i + 1) % num_edges];
+        let (lower, higher, direction) = if p0.y < p1.y {
+            (p0, p1, 1)
+        } else {
+            (p1, p0, -1)
+        };
+        edge_table.push(EdgeBucket {
+            ymax: higher.y,
+            ymin: lower.y,
+            x: lower.x,
+            sign: if lower.x > higher.x { 1 } else { -1 },
+            direction: direction,
+            dx: (higher.x - lower.x).abs(),
+            dy: (higher.y - lower.y).abs(),
+            sum: 0,
+        });
+    }
+    // sort the edge table by ymin
+    edge_table.sort_unstable_by_key(|p| p.ymin);
+
+    // create active list
+    let mut active_list = Vec::<EdgeBucket>::new();
+
+    // initialise scanline with lowest ymin
+    let mut scanline = edge_table[0].clone().ymin;
+
+    while edge_table.len() > 0 {
+        // remove edges that end on the current scanline
+        edge_table.retain(|edge| if edge.ymax == scanline { false } else { true });
+        active_list.retain(|edge| if edge.ymax == scanline { false } else { true });
+
+        // push edges that start on this scanline to the active list
+        for edge in edge_table.iter() {
+            if edge.ymin == scanline {
+                active_list.push(edge.clone());
+            }
+        }
+
+        // sort active list by ymin, ascending
+        active_list.sort_unstable_by_key(|p| p.x);
+
+        // for every pair of edges on the active list,
+        // apply the fill method selected
+        if fill {
+            let mut prev_x = 0;
+            let mut winding_count = 0;
+            for edge in active_list.iter() {
+                if winding_count != 0 {
+                    for x in prev_x..edge.x {
+                        write_pixel(Point2 { x: x, y: scanline });
+                    }
+                }
+                prev_x = edge.x;
+                winding_count += edge.direction;
+            }
+        } else {
+            for pair in active_list.chunks(2) {
+                if pair.len() != 2 {
+                    continue;
+                }
+                if pair[0].x != pair[1].x {
+                    write_pixel(Point2 {
+                        x: pair[0].x,
+                        y: scanline,
+                    });
+                    write_pixel(Point2 {
+                        x: pair[1].x - 1,
+                        y: scanline,
+                    });
+                }
+            }
+        }
+
+        // increment scanline
+        scanline += 1;
+
+        // adjust the x of each edge based on its gradient
+        for edge in &mut active_list {
+            if edge.dx != 0 {
+                edge.sum += edge.dx;
+            }
+            while edge.sum >= edge.dy {
+                edge.x -= edge.sign;
+                edge.sum -= edge.dy;
+            }
+        }
+    }
+
+    // calculate bounding box
+    let (min_xy, max_xy) = points.iter().fold(
+        (
+            Point2 {
+                y: std::i32::MAX,
+                x: std::i32::MAX,
+            },
+            Point2 {
+                y: std::i32::MIN,
+                x: std::i32::MIN,
+            },
+        ),
+        |acc, p| {
+            (
+                Point2 {
+                    y: min!(acc.0.y, p.y),
+                    x: min!(acc.0.x, p.x),
+                },
+                Point2 {
+                    y: max!(acc.1.y, p.y),
+                    x: max!(acc.1.x, p.x),
+                },
+            )
+        },
+    );
+    mxcfb_rect {
+        top: min_xy.y as u32,
+        left: min_xy.x as u32,
+        width: (max_xy.x - min_xy.x) as u32,
+        height: (max_xy.y - min_xy.y) as u32,
+    }
+}
+
+/// Helper function to sample pixels on the bezier curve.
+fn sample_bezier(
+    startpt: Point2<f32>,
+    ctrlpt: Point2<f32>,
+    endpt: Point2<f32>,
+    samples: i32,
+) -> Vec<(f32, Point2<f32>)> {
+    let mut points = Vec::new();
+    for i in 0..samples {
+        let t = (i as f32) / (samples - 1) as f32;
+        let precisept = Point2 {
+            x: (1.0 - t).powf(2.0) * startpt.x
+                + 2.0 * (1.0 - t) * t * ctrlpt.x
+                + t.powf(2.0) * endpt.x,
+            y: (1.0 - t).powf(2.0) * startpt.y
+                + 2.0 * (1.0 - t) * t * ctrlpt.y
+                + t.powf(2.0) * endpt.y,
+        };
+        points.push((t, precisept));
+    }
+    points
+}
+
+pub fn draw_dynamic_bezier<F>(
+    write_pixel: &mut F,
+    startpt: (Point2<f32>, f32),
+    ctrlpt: (Point2<f32>, f32),
+    endpt: (Point2<f32>, f32),
+    samples: i32,
+) -> mxcfb_rect
+where
+    F: FnMut(Point2<i32>),
+{
+    let mut left_edge = Vec::<Point2<i32>>::new();
+    let mut right_edge = Vec::<Point2<i32>>::new();
+    let mut prev_left_pt = Point2 {
+        x: std::i32::MIN,
+        y: std::i32::MIN,
+    };
+    let mut prev_right_pt = Point2 {
+        x: std::i32::MIN,
+        y: std::i32::MIN,
+    };
+    for (t, pt) in sample_bezier(startpt.0, ctrlpt.0, endpt.0, samples) {
+        // interpolate width
+        let width = 2.0 * if t < 0.5 {
+            startpt.1 * (0.5 - t) + ctrlpt.1 * t
+        } else {
+            ctrlpt.1 * (1.0 - t) + endpt.1 * (t - 0.5)
+        };
+
+        // calculate tangent
+        let velocity = 2.0 * (1.0 - t) * (ctrlpt.0 - startpt.0) + 2.0 * t * (endpt.0 - ctrlpt.0);
+        let speed = velocity.magnitude();
+        let tangent = if speed > 0.0 {
+            velocity / speed
+        } else {
+            // handle case where control point == start/end point
+            let extent = startpt.0 - endpt.0;
+            if extent.magnitude() > 0.0 {
+                extent / extent.magnitude()
+            } else {
+                // all points are the same, so no tangent exists
+                Vector2 { x: 0.0, y: 0.0 }
+            }
+        };
+        let left_pt = (pt + Vector2 {
+            x: -tangent.y * width / 2.0,
+            y: tangent.x * width / 2.0,
+        })
+        .cast()
+        .unwrap();
+        if left_pt != prev_left_pt {
+            left_edge.push(left_pt);
+            prev_left_pt = left_pt;
+        }
+        let right_pt = (pt + Vector2 {
+            x: tangent.y * width / 2.0,
+            y: -tangent.x * width / 2.0,
+        })
+        .cast()
+        .unwrap();
+        if right_pt != prev_right_pt {
+            right_edge.push(right_pt);
+            prev_right_pt = right_pt;
+        }
+    }
+    right_edge.reverse();
+    left_edge.append(&mut right_edge);
+    if left_edge.len() > 2 {
+        draw_polygon(write_pixel, left_edge, true)
+    } else {
+        mxcfb_rect::invalid()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    struct Mock<'a> {
+        pixel_writes: &'a mut Vec<Point2<i32>>,
+    }
+    impl<'a> Mock<'a> {
+        fn write_pixel(&mut self, point: Point2<i32>) {
+            self.pixel_writes.push(point)
+        }
+        fn clear(&mut self) {
+            self.pixel_writes.clear()
+        }
+    }
+
+    #[test]
+    fn test_draw_1px_square_polygon() {
+        let mut mock = Mock {
+            pixel_writes: &mut Vec::new(),
+        };
+        let points = vec![
+            Point2 { x: 100, y: 100 },
+            Point2 { x: 100, y: 101 },
+            Point2 { x: 101, y: 101 },
+            Point2 { x: 101, y: 100 },
+        ];
+        draw_polygon(&mut |p| mock.write_pixel(p), points, true);
+        assert_eq!(mock.pixel_writes, &vec![Point2 { x: 100, y: 100 }]);
+    }
+
+    #[test]
+    fn test_draw_2x1px_triangle_pair() {
+        let mut mock = Mock {
+            pixel_writes: &mut Vec::new(),
+        };
+        let points = vec![
+            Point2 { x: 100, y: 100 },
+            Point2 { x: 100, y: 101 },
+            Point2 { x: 102, y: 100 },
+        ];
+        draw_polygon(&mut |p| mock.write_pixel(p), points, true);
+        let points = vec![
+            Point2 { x: 100, y: 101 },
+            Point2 { x: 102, y: 100 },
+            Point2 { x: 102, y: 101 },
+        ];
+        draw_polygon(&mut |p| mock.write_pixel(p), points, true);
+        assert_eq!(
+            mock.pixel_writes,
+            &vec![Point2 { x: 100, y: 100 }, Point2 { x: 101, y: 100 }]
+        );
+    }
+}

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -30,7 +30,7 @@ pub trait FramebufferIO {
     ) -> Result<u32, &'static str>;
 }
 
-pub mod graphics;
+mod graphics;
 
 pub mod draw;
 pub trait FramebufferDraw {

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -12,9 +12,9 @@ use image;
 pub trait FramebufferIO {
     /// Writes an arbitrary length frame into the framebuffer
     fn write_frame(&mut self, frame: &[u8]);
-    /// Writes a single pixel at `(y, x)` with value `v`
+    /// Writes a single pixel at `pos` with value `v`
     fn write_pixel(&mut self, pos: cgmath::Point2<i32>, v: common::color);
-    /// Reads the value of the pixel at `(y, x)`
+    /// Reads the value of the pixel at `pos`
     fn read_pixel(&self, pos: cgmath::Point2<u32>) -> common::color;
     /// Reads the value at offset `ofst` from the mmapp'ed framebuffer region
     fn read_offset(&self, ofst: isize) -> u8;
@@ -29,6 +29,8 @@ pub trait FramebufferIO {
         data: &[u8],
     ) -> Result<u32, &'static str>;
 }
+
+pub mod graphics;
 
 pub mod draw;
 pub trait FramebufferDraw {
@@ -57,6 +59,13 @@ pub trait FramebufferDraw {
         rad: u32,
         c: common::color,
     ) -> common::mxcfb_rect;
+    /// Draws a polygon
+    fn draw_polygon(
+        &mut self,
+        Vec<cgmath::Point2<i32>>,
+        fill: bool,
+        c: common::color,
+    ) -> common::mxcfb_rect;
     /// Draws a bezier curve begining at `startpt`, with control point `ctrlpt`, ending at `endpt` with `color`
     fn draw_bezier(
         &mut self,
@@ -64,6 +73,17 @@ pub trait FramebufferDraw {
         ctrlpt: cgmath::Point2<f32>,
         endpt: cgmath::Point2<f32>,
         width: f32,
+        samples: i32,
+        v: common::color,
+    ) -> common::mxcfb_rect;
+    /// Draws a bezier curve begining at `startpt`, with control point `ctrlpt`, ending at `endpt`
+    /// with a width at each point and color `color`
+    fn draw_dynamic_bezier(
+        &mut self,
+        startpt: (cgmath::Point2<f32>, f32),
+        ctrlpt: (cgmath::Point2<f32>, f32),
+        endpt: (cgmath::Point2<f32>, f32),
+        samples: i32,
         v: common::color,
     ) -> common::mxcfb_rect;
     /// Draws `text` at `pos` with `color` using scale `size`

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -62,7 +62,7 @@ pub trait FramebufferDraw {
     /// Draws a polygon
     fn draw_polygon(
         &mut self,
-        Vec<cgmath::Point2<i32>>,
+        &[cgmath::Point2<i32>],
         fill: bool,
         c: common::color,
     ) -> common::mxcfb_rect;

--- a/src/input/wacom.rs
+++ b/src/input/wacom.rs
@@ -71,12 +71,12 @@ pub enum WacomEvent {
         state: bool,
     },
     Hover {
-        position: cgmath::Point2<u16>,
+        position: cgmath::Point2<f32>,
         distance: u16,
         tilt: cgmath::Vector2<u16>,
     },
     Draw {
-        position: cgmath::Point2<u16>,
+        position: cgmath::Point2<f32>,
         pressure: u16,
         tilt: cgmath::Vector2<u16>,
     },
@@ -93,8 +93,8 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Option<InputE
             Some(WacomPen::ToolPen) => Some(InputEvent::WacomEvent {
                 event: WacomEvent::Hover {
                     position: cgmath::Point2 {
-                        x: (f32::from(state.last_x.load(Ordering::Relaxed)) * WACOM_HSCALAR) as u16,
-                        y: (f32::from(state.last_y.load(Ordering::Relaxed)) * WACOM_VSCALAR) as u16,
+                        x: (f32::from(state.last_x.load(Ordering::Relaxed)) * WACOM_HSCALAR),
+                        y: (f32::from(state.last_y.load(Ordering::Relaxed)) * WACOM_VSCALAR),
                     },
                     distance: state.last_dist.load(Ordering::Relaxed) as u16,
                     tilt: cgmath::Vector2 {
@@ -106,8 +106,8 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Option<InputE
             Some(WacomPen::Touch) => Some(InputEvent::WacomEvent {
                 event: WacomEvent::Draw {
                     position: cgmath::Point2 {
-                        x: (f32::from(state.last_x.load(Ordering::Relaxed)) * WACOM_HSCALAR) as u16,
-                        y: (f32::from(state.last_y.load(Ordering::Relaxed)) * WACOM_VSCALAR) as u16,
+                        x: (f32::from(state.last_x.load(Ordering::Relaxed)) * WACOM_HSCALAR),
+                        y: (f32::from(state.last_y.load(Ordering::Relaxed)) * WACOM_VSCALAR),
                     },
                     pressure: state.last_pressure.load(Ordering::Relaxed),
                     tilt: cgmath::Vector2 {


### PR DESCRIPTION
Summary:
- add polygon rasterisation
- base bezier drawing on rasterisation
- add bezier method with width interpolation
- parameterise bezier drawing by sample count
- refactor graphics functions into separate package with testability
- change circle filling to use plain squares comparison
- return floats for pen positions
- smooth out pen drawing by using sample midpoints
- add diamond touch mode for demonstration of vector drawing
- add -- and ++ buttons for quick brush sizing (+/-10)

Points of note:
- This does not fix the text drawing issue introduced in the previous PR. That will require a separate investigation.
- This is a breaking API change, but less so than the cgmath change.
- By making the `graphics` module non-public, functions can be freely moved into it as necessary without API changes. Functionality it provides that is not possible externally (e.g. stamping arbitrary draw functions along a line) can be exposed later if desired as an API change.
- Given that there are a number of changes in this PR, if there is any change that you wish to be split out I can certainly attempt to do so. Some are more intertwined than others.