### PR TITLE
Closes #24

### DIFF
--- a/src/battery.rs
+++ b/src/battery.rs
@@ -5,7 +5,7 @@ use std::io::Read;
 
 fn read_attribute(attr: &str) -> Result<String, String> {
     let mut data = String::new();
-    match File::open(format!("/sys/class/power_supply/bq27441/{0}", attr)) {
+    match File::open(format!("/sys/class/power_supply/bq27441-0/{0}", attr)) {
         Err(e) => Err(format!("Unable to open file: {0}", e)),
         Ok(ref mut f) => match f.read_to_string(&mut data).unwrap_or(0) {
             0 => Err("Unable to read file".to_owned()),


### PR DESCRIPTION
The path to the battery information changed with the latest update (1.8).
This works (I just tested it), but this would break the build for libremarkables < 1.8, so I open the PR to discuss the best solution.

Possible solutions that came to my mind:
- a) Notice it in the README as a breaking change
- b) Check 1.7 path and if not available use the 1.8 path

Bests