### PR TITLE
Fix initial rendering

### DIFF
--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -43,14 +43,13 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
             .open(path_to_device)
             .unwrap();
 
-        let fix_screen_info = Framebuffer::get_fix_screeninfo(&device);
         let mut var_screen_info = Framebuffer::get_var_screeninfo(&device);
-        var_screen_info.xres = 1872;
-        var_screen_info.yres = 1404;
+        var_screen_info.xres = 1404;
+        var_screen_info.yres = 1872;
         var_screen_info.rotate = 1;
         var_screen_info.width = 0xffff_ffff;
         var_screen_info.height = 0xffff_ffff;
-        var_screen_info.pixclock = 160_000_000;
+        var_screen_info.pixclock = 6250;
         var_screen_info.left_margin = 32;
         var_screen_info.right_margin = 326;
         var_screen_info.upper_margin = 4;
@@ -63,6 +62,7 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
 
         Framebuffer::put_var_screeninfo(&device, &mut var_screen_info);
 
+        let fix_screen_info = Framebuffer::get_fix_screeninfo(&device);
         let frame_length = (fix_screen_info.line_length * var_screen_info.yres) as usize;
         let mem_map = MemoryMap::new(
             frame_length,


### PR DESCRIPTION
When an application that is using libremarkable is started right after
booting the device, it doesn't display anything.

In order to fix this problem, `pixclock` is set to 6250. This will result
in the expected flashing of the display as when starting other applications.
Though the rendering will be garbled/corrupted.

In order to fix that, the fix screen info needs to be read after the
var screen info was set. The fix screen info returns the number of lines
based on the rotation of the screen. Right after starting the reMarkable
the screen is set to landscape mode. libremarkable sets it to portrait mode
via the var screen info, which changes the line length of the fix screen info.

I also adjusted the `xres` and `yres` in the code to reflect the values
after the `ioctl` was successfully sent. Using the flipped values would
still work as they are automatically corrected, but using the right values
makes the code easier to understand.

I've tested it with the `demo`, both the traditional build as well as with
the musl build.

Fixes #32.