### PR TITLE
Use Rust 2018 edition idioms

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ hlua = "0.4.1"
 aabb-quadtree = "0.1.0"
 zstd = "0.5.1"
 stopwatch = "0.0.7"
-atomic = { version = "0.4.5", features = ["nightly"] }
+atomic = { version = "0.5.0" }
 cgmath = "0.17.0"
 fxhash = "0.2.1"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ crate-type = ["bin"]
 
 [dev-dependencies]
 # For spy
-redhook = "1.0.0"
+redhook = "2.0.0"
 libc = "0.2.69"
 lazy_static = "1.4.0"
 # For demo

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT"
 description = "The only publicly available Framework for developing applications for the Remarkable Paper Tablet w/ Low Latency Partial Refresh Support"
 readme = "README.md"
 exclude = [ "reference-material/*", "legacy-c-impl/*", "private/*" ]
+edition = "2018"
 
 [dependencies]
 log = "0.4.8"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -4,7 +4,7 @@ extern crate lazy_static;
 
 #[macro_use]
 extern crate log;
-extern crate env_logger;
+use env_logger;
 
 #[macro_use]
 extern crate libremarkable;
@@ -24,10 +24,8 @@ use libremarkable::{appctx, battery, image};
 #[cfg(feature = "enable-runtime-benchmarking")]
 use libremarkable::stopwatch;
 
-extern crate chrono;
 use chrono::{DateTime, Local};
 
-extern crate atomic;
 use atomic::Atomic;
 
 use std::collections::VecDeque;
@@ -120,7 +118,7 @@ lazy_static! {
 // ## Button Handlers
 // ####################
 
-fn on_save_canvas(app: &mut appctx::ApplicationContext, _element: UIElementHandle) {
+fn on_save_canvas(app: &mut appctx::ApplicationContext<'_>, _element: UIElementHandle) {
     start_bench!(stopwatch, save_canvas);
     let framebuffer = app.get_framebuffer_ref();
     match framebuffer.dump_region(CANVAS_REGION) {
@@ -137,7 +135,7 @@ fn on_save_canvas(app: &mut appctx::ApplicationContext, _element: UIElementHandl
     end_bench!(save_canvas);
 }
 
-fn on_zoom_out(app: &mut appctx::ApplicationContext, _element: UIElementHandle) {
+fn on_zoom_out(app: &mut appctx::ApplicationContext<'_>, _element: UIElementHandle) {
     start_bench!(stopwatch, zoom_out);
     let framebuffer = app.get_framebuffer_ref();
     match framebuffer.dump_region(CANVAS_REGION) {
@@ -183,7 +181,7 @@ fn on_zoom_out(app: &mut appctx::ApplicationContext, _element: UIElementHandle) 
     end_bench!(zoom_out);
 }
 
-fn on_blur_canvas(app: &mut appctx::ApplicationContext, _element: UIElementHandle) {
+fn on_blur_canvas(app: &mut appctx::ApplicationContext<'_>, _element: UIElementHandle) {
     start_bench!(stopwatch, blur_canvas);
     let framebuffer = app.get_framebuffer_ref();
     match framebuffer.dump_region(CANVAS_REGION) {
@@ -217,7 +215,7 @@ fn on_blur_canvas(app: &mut appctx::ApplicationContext, _element: UIElementHandl
     end_bench!(blur_canvas);
 }
 
-fn on_invert_canvas(app: &mut appctx::ApplicationContext, element: UIElementHandle) {
+fn on_invert_canvas(app: &mut appctx::ApplicationContext<'_>, element: UIElementHandle) {
     start_bench!(stopwatch, invert);
     let framebuffer = app.get_framebuffer_ref();
     match framebuffer.dump_region(CANVAS_REGION) {
@@ -248,7 +246,7 @@ fn on_invert_canvas(app: &mut appctx::ApplicationContext, element: UIElementHand
     on_toggle_eraser(app, element);
 }
 
-fn on_load_canvas(app: &mut appctx::ApplicationContext, _element: UIElementHandle) {
+fn on_load_canvas(app: &mut appctx::ApplicationContext<'_>, _element: UIElementHandle) {
     start_bench!(stopwatch, load_canvas);
     match *SAVED_CANVAS.lock().unwrap() {
         None => {}
@@ -275,7 +273,7 @@ fn on_load_canvas(app: &mut appctx::ApplicationContext, _element: UIElementHandl
     end_bench!(load_canvas);
 }
 
-fn on_touch_rustlogo(app: &mut appctx::ApplicationContext, _element: UIElementHandle) {
+fn on_touch_rustlogo(app: &mut appctx::ApplicationContext<'_>, _element: UIElementHandle) {
     let framebuffer = app.get_framebuffer_ref();
     let new_press_count = {
         let mut v = G_COUNTER.lock().unwrap();
@@ -312,7 +310,7 @@ fn on_touch_rustlogo(app: &mut appctx::ApplicationContext, _element: UIElementHa
     );
 }
 
-fn on_toggle_eraser(app: &mut appctx::ApplicationContext, _: UIElementHandle) {
+fn on_toggle_eraser(app: &mut appctx::ApplicationContext<'_>, _: UIElementHandle) {
     let (new_mode, name) = match G_DRAW_MODE.load(Ordering::Relaxed) {
         DrawMode::Erase(s) => (DrawMode::Draw(s), "Black".to_owned()),
         DrawMode::Draw(s) => (DrawMode::Erase(s), "White".to_owned()),
@@ -326,7 +324,7 @@ fn on_toggle_eraser(app: &mut appctx::ApplicationContext, _: UIElementHandle) {
     app.draw_element("colorIndicator");
 }
 
-fn on_change_touchdraw_mode(app: &mut appctx::ApplicationContext, _: UIElementHandle) {
+fn on_change_touchdraw_mode(app: &mut appctx::ApplicationContext<'_>, _: UIElementHandle) {
     let new_val = G_TOUCH_MODE.load(Ordering::Relaxed).toggle();
     G_TOUCH_MODE.store(new_val, Ordering::Relaxed);
 
@@ -343,7 +341,7 @@ fn on_change_touchdraw_mode(app: &mut appctx::ApplicationContext, _: UIElementHa
 // ## Miscellaneous
 // ####################
 
-fn draw_color_test_rgb(app: &mut appctx::ApplicationContext, _element: UIElementHandle) {
+fn draw_color_test_rgb(app: &mut appctx::ApplicationContext<'_>, _element: UIElementHandle) {
     let fb = app.get_framebuffer_ref();
 
     let img_rgb565 = image::load_from_memory(include_bytes!("../assets/colorspace.png")).unwrap();
@@ -362,7 +360,7 @@ fn draw_color_test_rgb(app: &mut appctx::ApplicationContext, _element: UIElement
     );
 }
 
-fn change_brush_width(app: &mut appctx::ApplicationContext, delta: i32) {
+fn change_brush_width(app: &mut appctx::ApplicationContext<'_>, delta: i32) {
     let current = G_DRAW_MODE.load(Ordering::Relaxed);
     let current_size = current.get_size() as i32;
     let proposed_size = current_size + delta;
@@ -386,7 +384,7 @@ fn change_brush_width(app: &mut appctx::ApplicationContext, delta: i32) {
     app.draw_element("displaySize");
 }
 
-fn loop_update_topbar(app: &mut appctx::ApplicationContext, millis: u64) {
+fn loop_update_topbar(app: &mut appctx::ApplicationContext<'_>, millis: u64) {
     let time_label = app.get_element_by_name("time").unwrap();
     let battery_label = app.get_element_by_name("battery").unwrap();
     loop {
@@ -417,7 +415,7 @@ fn loop_update_topbar(app: &mut appctx::ApplicationContext, millis: u64) {
 // ## Input Handlers
 // ####################
 
-fn on_wacom_input(app: &mut appctx::ApplicationContext, input: wacom::WacomEvent) {
+fn on_wacom_input(app: &mut appctx::ApplicationContext<'_>, input: wacom::WacomEvent) {
     match input {
         wacom::WacomEvent::Draw {
             position,
@@ -520,7 +518,7 @@ fn on_wacom_input(app: &mut appctx::ApplicationContext, input: wacom::WacomEvent
     };
 }
 
-fn on_touch_handler(app: &mut appctx::ApplicationContext, input: multitouch::MultitouchEvent) {
+fn on_touch_handler(app: &mut appctx::ApplicationContext<'_>, input: multitouch::MultitouchEvent) {
     let framebuffer = app.get_framebuffer_ref();
     match input {
         multitouch::MultitouchEvent::Press { finger }
@@ -591,7 +589,7 @@ fn on_touch_handler(app: &mut appctx::ApplicationContext, input: multitouch::Mul
     }
 }
 
-fn on_button_press(app: &mut appctx::ApplicationContext, input: gpio::GPIOEvent) {
+fn on_button_press(app: &mut appctx::ApplicationContext<'_>, input: gpio::GPIOEvent) {
     let (btn, new_state) = match input {
         gpio::GPIOEvent::Press { button } => (button, true),
         gpio::GPIOEvent::Unpress { button } => (button, false),
@@ -661,7 +659,7 @@ fn main() {
 
     // Takes callback functions as arguments
     // They are called with the event and the &mut framebuffer
-    let mut app: appctx::ApplicationContext =
+    let mut app: appctx::ApplicationContext<'_> =
         appctx::ApplicationContext::new(on_button_press, on_wacom_input, on_touch_handler);
 
     // Alternatively we could have called `app.execute_lua("fb.clear()")`

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -1,13 +1,3 @@
-#![feature(nll)]
-#[macro_use]
-extern crate lazy_static;
-
-#[macro_use]
-extern crate log;
-use env_logger;
-
-#[macro_use]
-extern crate libremarkable;
 use libremarkable::framebuffer::cgmath;
 use libremarkable::framebuffer::cgmath::EuclideanSpace;
 use libremarkable::framebuffer::common::*;
@@ -20,13 +10,15 @@ use libremarkable::ui_extensions::element::{
     UIConstraintRefresh, UIElement, UIElementHandle, UIElementWrapper,
 };
 use libremarkable::{appctx, battery, image};
+use libremarkable::{end_bench, start_bench};
 
 #[cfg(feature = "enable-runtime-benchmarking")]
 use libremarkable::stopwatch;
 
-use chrono::{DateTime, Local};
-
 use atomic::Atomic;
+use chrono::{DateTime, Local};
+use lazy_static::lazy_static;
+use log::info;
 
 use std::collections::VecDeque;
 use std::process::Command;

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -433,10 +433,10 @@ fn on_wacom_input(app: &mut appctx::ApplicationContext, input: wacom::WacomEvent
                 if UNPRESS_OBSERVED.fetch_and(false, Ordering::Relaxed) {
                     let region = app
                         .find_active_region(position.y.round() as u16, position.x.round() as u16);
-                    let element = region.map(|(region, _)| { region.element.clone() });
+                    let element = region.map(|(region, _)| region.element.clone());
                     match element {
-                      Some(element) => (region.unwrap().0.handler)(app, element),
-                      None => {}
+                        Some(element) => (region.unwrap().0.handler)(app, element),
+                        None => {}
                     }
                 }
                 return;
@@ -523,8 +523,8 @@ fn on_wacom_input(app: &mut appctx::ApplicationContext, input: wacom::WacomEvent
 fn on_touch_handler(app: &mut appctx::ApplicationContext, input: multitouch::MultitouchEvent) {
     let framebuffer = app.get_framebuffer_ref();
     match input {
-        multitouch::MultitouchEvent::Press { finger } |
-        multitouch::MultitouchEvent::Move { finger } => {
+        multitouch::MultitouchEvent::Press { finger }
+        | multitouch::MultitouchEvent::Move { finger } => {
             if !CANVAS_REGION.contains_point(&finger.pos.cast().unwrap()) {
                 return;
             }
@@ -675,7 +675,7 @@ fn main() {
             refresh: UIConstraintRefresh::Refresh,
 
             /* We could have alternatively done this:
-            
+
                // Create a clickable region for multitouch input and associate it with its handler fn
                app.create_active_region(10, 900, 240, 480, on_touch_rustlogo);
             */

--- a/examples/live.rs
+++ b/examples/live.rs
@@ -1,5 +1,3 @@
-use tiny_http;
-
 use libremarkable::framebuffer;
 use libremarkable::framebuffer::core::Framebuffer;
 use libremarkable::framebuffer::{FramebufferBase, FramebufferIO};

--- a/examples/live.rs
+++ b/examples/live.rs
@@ -1,5 +1,4 @@
-extern crate libremarkable;
-extern crate tiny_http;
+use tiny_http;
 
 use libremarkable::framebuffer;
 use libremarkable::framebuffer::core::Framebuffer;

--- a/examples/spy.rs
+++ b/examples/spy.rs
@@ -4,15 +4,13 @@ extern crate lazy_static;
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-extern crate libc;
+use libc;
 
 use libc::c_int;
 use libc::intptr_t;
 
 #[macro_use]
 extern crate redhook;
-
-extern crate libremarkable;
 
 use libremarkable::framebuffer::common::*;
 use libremarkable::framebuffer::mxcfb::*;

--- a/examples/spy.rs
+++ b/examples/spy.rs
@@ -104,12 +104,12 @@ hook! {
 
     let res = real!(ioctl)(fd, request, p1, p2, p3, p4);
     let event = ioctl_intercept_event {
-      fd: fd,
-      request: request,
-      p1: p1,
-      p2: p2,
-      p3: p3,
-      p4: p4,
+      fd,
+      request,
+      p1,
+      p2,
+      p3,
+      p4,
       ret: res,
     };
 
@@ -130,6 +130,6 @@ hook! {
         MXCFB_SEND_UPDATE => handle_send_update(event),
         _ => println!("unknown_ioctl({0:#?})", event),
     }
-    return res;
+    res
   }
 }

--- a/examples/spy.rs
+++ b/examples/spy.rs
@@ -1,16 +1,10 @@
-#[macro_use]
-extern crate lazy_static;
-
 use std::collections::HashMap;
 use std::sync::Mutex;
 
-use libc;
-
+use lazy_static::lazy_static;
 use libc::c_int;
 use libc::intptr_t;
-
-#[macro_use]
-extern crate redhook;
+use redhook::{hook, real};
 
 use libremarkable::framebuffer::common::*;
 use libremarkable::framebuffer::mxcfb::*;

--- a/src/appctx.rs
+++ b/src/appctx.rs
@@ -1,4 +1,3 @@
-use std;
 use std::cell::UnsafeCell;
 use std::ops::DerefMut;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -7,7 +6,6 @@ use std::sync::RwLock;
 use std::collections::HashMap;
 
 use crate::input::ev;
-use image;
 
 use crate::framebuffer::common::*;
 
@@ -16,7 +14,6 @@ use crate::ui_extensions::element::{
     UIElementWrapper,
 };
 use crate::ui_extensions::luaext;
-use hlua;
 use hlua::Lua;
 
 use aabb_quadtree::{geom, ItemId, QuadTree};
@@ -32,9 +29,6 @@ use crate::input::gpio::GPIOEvent;
 use crate::input::multitouch::MultitouchEvent;
 use crate::input::wacom::WacomEvent;
 use crate::input::{InputDevice, InputEvent};
-
-#[cfg(feature = "enable-runtime-benchmarking")]
-use stopwatch;
 
 unsafe impl<'a> Send for ApplicationContext<'a> {}
 unsafe impl<'a> Sync for ApplicationContext<'a> {}

--- a/src/appctx.rs
+++ b/src/appctx.rs
@@ -52,13 +52,13 @@ pub struct ApplicationContext<'a> {
     input_rx: std::sync::mpsc::Receiver<InputEvent>,
 
     button_ctx: RwLock<Option<ev::EvDevContext>>,
-    on_button: fn(&mut ApplicationContext, GPIOEvent),
+    on_button: fn(&mut ApplicationContext<'_>, GPIOEvent),
 
     wacom_ctx: RwLock<Option<ev::EvDevContext>>,
-    on_wacom: fn(&mut ApplicationContext, WacomEvent),
+    on_wacom: fn(&mut ApplicationContext<'_>, WacomEvent),
 
     touch_ctx: RwLock<Option<ev::EvDevContext>>,
-    on_touch: fn(&mut ApplicationContext, MultitouchEvent),
+    on_touch: fn(&mut ApplicationContext<'_>, MultitouchEvent),
 
     active_regions: QuadTree<ActiveRegionHandler>,
     ui_elements: HashMap<String, UIElementHandle>,
@@ -92,9 +92,9 @@ impl<'a> ApplicationContext<'a> {
     }
 
     pub fn new(
-        on_button: fn(&mut ApplicationContext, GPIOEvent),
-        on_wacom: fn(&mut ApplicationContext, WacomEvent),
-        on_touch: fn(&mut ApplicationContext, MultitouchEvent),
+        on_button: fn(&mut ApplicationContext<'_>, GPIOEvent),
+        on_wacom: fn(&mut ApplicationContext<'_>, WacomEvent),
+        on_touch: fn(&mut ApplicationContext<'_>, MultitouchEvent),
     ) -> ApplicationContext<'static> {
         let framebuffer = box core::Framebuffer::new("/dev/fb0");
         let yres = framebuffer.var_screen_info.yres;
@@ -131,7 +131,7 @@ impl<'a> ApplicationContext<'a> {
 
         // Reluctantly resort to using a static global to associate the lua context with the
         // one and only framebuffer that's going to be used
-        unsafe { luaext::G_FB = res.framebuffer.deref_mut() as *mut core::Framebuffer };
+        unsafe { luaext::G_FB = res.framebuffer.deref_mut() as *mut core::Framebuffer<'_> };
 
         let mut nms = lua.empty_array("fb");
         // Clears and refreshes the entire screen

--- a/src/appctx.rs
+++ b/src/appctx.rs
@@ -17,6 +17,7 @@ use crate::ui_extensions::luaext;
 use hlua::Lua;
 
 use aabb_quadtree::{geom, ItemId, QuadTree};
+use log::warn;
 
 use crate::framebuffer::cgmath;
 use crate::framebuffer::core;

--- a/src/appctx.rs
+++ b/src/appctx.rs
@@ -503,10 +503,11 @@ impl<'a> ApplicationContext<'a> {
                 Ok(event) => match event {
                     InputEvent::GPIO { event } => {
                         (self.on_button)(appref, event);
-                    },
+                    }
                     InputEvent::MultitouchEvent { event } => {
                         // Check for and notify clickable active regions for multitouch events
-                        if let MultitouchEvent::Press { finger } | MultitouchEvent::Move { finger } = event
+                        if let MultitouchEvent::Press { finger }
+                        | MultitouchEvent::Move { finger } = event
                         {
                             let gseq = i32::from(finger.tracking_id);
                             if last_active_region_gesture_id != gseq {
@@ -519,10 +520,10 @@ impl<'a> ApplicationContext<'a> {
                             }
                         }
                         (self.on_touch)(appref, event);
-                    },
+                    }
                     InputEvent::WacomEvent { event } => {
                         (self.on_wacom)(appref, event);
-                    },
+                    }
                     _ => {}
                 },
             };
@@ -540,10 +541,11 @@ impl<'a> ApplicationContext<'a> {
             match event {
                 InputEvent::GPIO { event } => {
                     (self.on_button)(appref, event);
-                },
+                }
                 InputEvent::MultitouchEvent { event } => {
                     // Check for and notify clickable active regions for multitouch events
-                    if let MultitouchEvent::Press { finger } | MultitouchEvent::Move { finger } = event
+                    if let MultitouchEvent::Press { finger } | MultitouchEvent::Move { finger } =
+                        event
                     {
                         let gseq = i32::from(finger.tracking_id);
                         if last_active_region_gesture_id != gseq {
@@ -556,10 +558,10 @@ impl<'a> ApplicationContext<'a> {
                         }
                     }
                     (self.on_touch)(appref, event);
-                },
+                }
                 InputEvent::WacomEvent { event } => {
                     (self.on_wacom)(appref, event);
-                },
+                }
                 _ => {}
             }
         }
@@ -573,7 +575,7 @@ impl<'a> ApplicationContext<'a> {
             },
             2.0,
         ));
-        matches.first().map(|res| { (res.0, res.2) })
+        matches.first().map(|res| (res.0, res.2))
     }
 
     pub fn remove_active_region_at_point(&mut self, y: u16, x: u16) -> bool {

--- a/src/appctx.rs
+++ b/src/appctx.rs
@@ -91,7 +91,7 @@ impl<'a> ApplicationContext<'a> {
         on_wacom: fn(&mut ApplicationContext<'_>, WacomEvent),
         on_touch: fn(&mut ApplicationContext<'_>, MultitouchEvent),
     ) -> ApplicationContext<'static> {
-        let framebuffer = box core::Framebuffer::new("/dev/fb0");
+        let framebuffer = Box::new(core::Framebuffer::new("/dev/fb0"));
         let yres = framebuffer.var_screen_info.yres;
         let xres = framebuffer.var_screen_info.xres;
 

--- a/src/appctx.rs
+++ b/src/appctx.rs
@@ -6,32 +6,32 @@ use std::sync::RwLock;
 
 use std::collections::HashMap;
 
+use crate::input::ev;
 use image;
-use input::ev;
 
-use framebuffer::common::*;
+use crate::framebuffer::common::*;
 
-use hlua;
-use hlua::Lua;
-use ui_extensions::element::{
+use crate::ui_extensions::element::{
     ActiveRegionFunction, ActiveRegionHandler, UIConstraintRefresh, UIElementHandle,
     UIElementWrapper,
 };
-use ui_extensions::luaext;
+use crate::ui_extensions::luaext;
+use hlua;
+use hlua::Lua;
 
 use aabb_quadtree::{geom, ItemId, QuadTree};
 
-use framebuffer::cgmath;
-use framebuffer::core;
-use framebuffer::refresh::PartialRefreshMode;
-use framebuffer::FramebufferBase;
-use framebuffer::FramebufferDraw;
-use framebuffer::FramebufferRefresh;
+use crate::framebuffer::cgmath;
+use crate::framebuffer::core;
+use crate::framebuffer::refresh::PartialRefreshMode;
+use crate::framebuffer::FramebufferBase;
+use crate::framebuffer::FramebufferDraw;
+use crate::framebuffer::FramebufferRefresh;
 
-use input::gpio::GPIOEvent;
-use input::multitouch::MultitouchEvent;
-use input::wacom::WacomEvent;
-use input::{InputDevice, InputEvent};
+use crate::input::gpio::GPIOEvent;
+use crate::input::multitouch::MultitouchEvent;
+use crate::input::wacom::WacomEvent;
+use crate::input::{InputDevice, InputEvent};
 
 #[cfg(feature = "enable-runtime-benchmarking")]
 use stopwatch;

--- a/src/framebuffer/common.rs
+++ b/src/framebuffer/common.rs
@@ -223,8 +223,8 @@ impl mxcfb_rect {
         let bottom = std::cmp::max(self.top + self.height, p.y);
         let right = std::cmp::max(self.left + self.width, p.x);
         mxcfb_rect {
-            left: left,
-            top: top,
+            left,
+            top,
             width: right - left,
             height: bottom - top,
         }
@@ -236,17 +236,17 @@ impl mxcfb_rect {
         if self_is_empty && rect_is_empty {
             mxcfb_rect::invalid()
         } else if self_is_empty {
-            rect.clone()
+            *rect
         } else if rect_is_empty {
-            self.clone()
+            *self
         } else {
             let top = std::cmp::min(self.top, rect.top);
             let left = std::cmp::min(self.left, rect.left);
             let bottom = std::cmp::max(self.top + self.height, rect.top + rect.height);
             let right = std::cmp::max(self.left + self.width, rect.left + rect.width);
             mxcfb_rect {
-                left: left,
-                top: top,
+                left,
+                top,
                 width: right - left,
                 height: bottom - top,
             }

--- a/src/framebuffer/common.rs
+++ b/src/framebuffer/common.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 #![allow(non_camel_case_types)]
 use crate::framebuffer::cgmath;
 use crate::framebuffer::mxcfb::*;

--- a/src/framebuffer/common.rs
+++ b/src/framebuffer/common.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 #![allow(non_camel_case_types)]
-use framebuffer::cgmath;
-use framebuffer::mxcfb::*;
+use crate::framebuffer::cgmath;
+use crate::framebuffer::mxcfb::*;
 use std;
 
 /// This is to allow tests to run on systems with 64bit pointer types.

--- a/src/framebuffer/common.rs
+++ b/src/framebuffer/common.rs
@@ -2,7 +2,6 @@
 #![allow(non_camel_case_types)]
 use crate::framebuffer::cgmath;
 use crate::framebuffer::mxcfb::*;
-use std;
 
 /// This is to allow tests to run on systems with 64bit pointer types.
 /// It doesn't make a difference since we will be mocking the ioctl calls.

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -36,7 +36,7 @@ unsafe impl<'a> Send for Framebuffer<'a> {}
 unsafe impl<'a> Sync for Framebuffer<'a> {}
 
 impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
-    fn new(path_to_device: &str) -> Framebuffer {
+    fn new(path_to_device: &str) -> Framebuffer<'_> {
         let device = OpenOptions::new()
             .read(true)
             .write(true)

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use libc::ioctl;
 use mmap::MemoryMap;
 

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -1,8 +1,6 @@
 #![allow(dead_code)]
 
-use libc;
 use libc::ioctl;
-use mmap;
 use mmap::MemoryMap;
 
 use std::fs::{File, OpenOptions};

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -9,12 +9,12 @@ use std::fs::{File, OpenOptions};
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::AtomicU32;
 
-use framebuffer;
-use framebuffer::common::{
+use crate::framebuffer;
+use crate::framebuffer::common::{
     FBIOGET_FSCREENINFO, FBIOGET_VSCREENINFO, FBIOPUT_VSCREENINFO, MXCFB_DISABLE_EPDC_ACCESS,
     MXCFB_ENABLE_EPDC_ACCESS, MXCFB_SET_AUTO_UPDATE_MODE, MXCFB_SET_UPDATE_SCHEME,
 };
-use framebuffer::screeninfo::{FixScreeninfo, VarScreeninfo};
+use crate::framebuffer::screeninfo::{FixScreeninfo, VarScreeninfo};
 
 use rusttype::{Font, FontCollection};
 

--- a/src/framebuffer/draw.rs
+++ b/src/framebuffer/draw.rs
@@ -5,12 +5,12 @@ use libc;
 use line_drawing;
 use rusttype::{point, Scale};
 
-use framebuffer;
-use framebuffer::cgmath::*;
-use framebuffer::common::*;
-use framebuffer::core;
-use framebuffer::graphics;
-use framebuffer::FramebufferIO;
+use crate::framebuffer;
+use crate::framebuffer::cgmath::*;
+use crate::framebuffer::common::*;
+use crate::framebuffer::core;
+use crate::framebuffer::graphics;
+use crate::framebuffer::FramebufferIO;
 
 impl<'a> framebuffer::FramebufferDraw for core::Framebuffer<'a> {
     fn draw_image(&mut self, img: &RgbImage, pos: Point2<i32>) -> mxcfb_rect {

--- a/src/framebuffer/draw.rs
+++ b/src/framebuffer/draw.rs
@@ -1,8 +1,4 @@
-use std;
-
 use image::RgbImage;
-use libc;
-use line_drawing;
 use rusttype::{point, Scale};
 
 use crate::framebuffer;

--- a/src/framebuffer/graphics.rs
+++ b/src/framebuffer/graphics.rs
@@ -313,10 +313,6 @@ mod test {
         fn write_pixel(&mut self, point: Point2<i32>) {
             self.pixel_writes.push(point)
         }
-        #[allow(dead_code)]
-        fn clear(&mut self) {
-            self.pixel_writes.clear()
-        }
     }
 
     #[test]

--- a/src/framebuffer/graphics.rs
+++ b/src/framebuffer/graphics.rs
@@ -113,7 +113,7 @@ where
             ymin: lower.y,
             x: lower.x,
             sign: if lower.x > higher.x { 1 } else { -1 },
-            direction: direction,
+            direction,
             dx: (higher.x - lower.x).abs(),
             dy: (higher.y - lower.y).abs(),
             sum: 0,
@@ -126,17 +126,17 @@ where
     let mut active_list = Vec::<EdgeBucket>::new();
 
     // initialise scanline with lowest ymin
-    let mut scanline = edge_table[0].clone().ymin;
+    let mut scanline = edge_table[0].ymin;
 
-    while edge_table.len() > 0 {
+    while !edge_table.is_empty() {
         // remove edges that end on the current scanline
-        edge_table.retain(|edge| if edge.ymax == scanline { false } else { true });
-        active_list.retain(|edge| if edge.ymax == scanline { false } else { true });
+        edge_table.retain(|edge| edge.ymax != scanline);
+        active_list.retain(|edge| edge.ymax != scanline);
 
         // push edges that start on this scanline to the active list
         for edge in edge_table.iter() {
             if edge.ymin == scanline {
-                active_list.push(edge.clone());
+                active_list.push(*edge);
             }
         }
 
@@ -150,7 +150,7 @@ where
         for edge in active_list.iter() {
             if winding_count != 0 {
                 for x in prev_x..edge.x {
-                    write_pixel(Point2 { x: x, y: scanline });
+                    write_pixel(Point2 { x, y: scanline });
                 }
             }
             prev_x = edge.x;
@@ -315,6 +315,7 @@ mod test {
         fn write_pixel(&mut self, point: Point2<i32>) {
             self.pixel_writes.push(point)
         }
+        #[allow(dead_code)]
         fn clear(&mut self) {
             self.pixel_writes.clear()
         }

--- a/src/framebuffer/graphics.rs
+++ b/src/framebuffer/graphics.rs
@@ -1,7 +1,7 @@
 use std;
 
-use framebuffer::cgmath::*;
-use framebuffer::common::*;
+use crate::framebuffer::cgmath::*;
+use crate::framebuffer::common::*;
 
 macro_rules! min {
         ($x: expr) => ($x);

--- a/src/framebuffer/graphics.rs
+++ b/src/framebuffer/graphics.rs
@@ -250,11 +250,12 @@ where
     };
     for (t, pt) in sample_bezier(startpt.0, ctrlpt.0, endpt.0, samples) {
         // interpolate width
-        let width = 2.0 * if t < 0.5 {
-            startpt.1 * (0.5 - t) + ctrlpt.1 * t
-        } else {
-            ctrlpt.1 * (1.0 - t) + endpt.1 * (t - 0.5)
-        };
+        let width = 2.0
+            * if t < 0.5 {
+                startpt.1 * (0.5 - t) + ctrlpt.1 * t
+            } else {
+                ctrlpt.1 * (1.0 - t) + endpt.1 * (t - 0.5)
+            };
 
         // calculate tangent
         let velocity = 2.0 * (1.0 - t) * (ctrlpt.0 - startpt.0) + 2.0 * t * (endpt.0 - ctrlpt.0);
@@ -271,20 +272,22 @@ where
                 Vector2 { x: 0.0, y: 0.0 }
             }
         };
-        let left_pt = (pt + Vector2 {
-            x: -tangent.y * width / 2.0,
-            y: tangent.x * width / 2.0,
-        })
+        let left_pt = (pt
+            + Vector2 {
+                x: -tangent.y * width / 2.0,
+                y: tangent.x * width / 2.0,
+            })
         .cast()
         .unwrap();
         if left_pt != prev_left_pt {
             left_edge.push(left_pt);
             prev_left_pt = left_pt;
         }
-        let right_pt = (pt + Vector2 {
-            x: tangent.y * width / 2.0,
-            y: -tangent.x * width / 2.0,
-        })
+        let right_pt = (pt
+            + Vector2 {
+                x: tangent.y * width / 2.0,
+                y: -tangent.x * width / 2.0,
+            })
         .cast()
         .unwrap();
         if right_pt != prev_right_pt {

--- a/src/framebuffer/graphics.rs
+++ b/src/framebuffer/graphics.rs
@@ -1,5 +1,3 @@
-use std;
-
 use crate::framebuffer::cgmath::*;
 use crate::framebuffer::common::*;
 

--- a/src/framebuffer/io.rs
+++ b/src/framebuffer/io.rs
@@ -1,4 +1,6 @@
 #![allow(dead_code)]
+use log::error;
+
 use crate::framebuffer;
 use crate::framebuffer::cgmath;
 use crate::framebuffer::common;

--- a/src/framebuffer/io.rs
+++ b/src/framebuffer/io.rs
@@ -8,7 +8,7 @@ impl<'a> framebuffer::FramebufferIO for framebuffer::core::Framebuffer<'a> {
         unsafe {
             let begin = self.frame.data() as *mut u8;
             for (i, elem) in frame.iter().enumerate() {
-                begin.offset(i as isize).write_volatile(*elem);
+                begin.add(i).write_volatile(*elem);
             }
         }
     }
@@ -49,8 +49,8 @@ impl<'a> framebuffer::FramebufferIO for framebuffer::core::Framebuffer<'a> {
         let begin = self.frame.data() as *mut u8;
         let (c1, c2) = unsafe {
             (
-                begin.offset(curr_index as isize).read_volatile(),
-                begin.offset((curr_index + 1) as isize).read_volatile(),
+                begin.add(curr_index).read_volatile(),
+                begin.add(curr_index + 1).read_volatile(),
             )
         };
         framebuffer::common::color::NATIVE_COMPONENTS(c1, c2)

--- a/src/framebuffer/io.rs
+++ b/src/framebuffer/io.rs
@@ -1,4 +1,3 @@
-#![allow(dead_code)]
 use log::error;
 
 use crate::framebuffer;

--- a/src/framebuffer/io.rs
+++ b/src/framebuffer/io.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
-use framebuffer;
-use framebuffer::cgmath;
-use framebuffer::common;
+use crate::framebuffer;
+use crate::framebuffer::cgmath;
+use crate::framebuffer::common;
 
 impl<'a> framebuffer::FramebufferIO for framebuffer::core::Framebuffer<'a> {
     fn write_frame(&mut self, frame: &[u8]) {

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -8,7 +8,6 @@ pub mod io;
 
 pub use cgmath;
 
-use image;
 pub trait FramebufferIO {
     /// Writes an arbitrary length frame into the framebuffer
     fn write_frame(&mut self, frame: &[u8]);
@@ -109,7 +108,6 @@ pub trait FramebufferDraw {
     fn clear(&mut self);
 }
 
-use std;
 pub mod core;
 pub trait FramebufferBase<'a> {
     /// Creates a new instance of Framebuffer

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -175,6 +175,7 @@ pub trait FramebufferRefresh {
     ///    line than the original update line width, the EPDC would
     ///    cause screen artifacts by incorrectly handling the 8+ pixels
     ///    at the end of each line.
+    #[allow(clippy::too_many_arguments)]
     fn partial_refresh(
         &self,
         region: &common::mxcfb_rect,

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -113,7 +113,7 @@ use std;
 pub mod core;
 pub trait FramebufferBase<'a> {
     /// Creates a new instance of Framebuffer
-    fn new(path_to_device: &str) -> core::Framebuffer;
+    fn new(path_to_device: &str) -> core::Framebuffer<'_>;
     /// Toggles the EPD Controller (see https://wiki.mobileread.com/wiki/EPD_controller)
     fn set_epdc_access(&mut self, state: bool);
     /// Toggles autoupdate mode

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -62,7 +62,7 @@ pub trait FramebufferDraw {
     /// Draws a polygon
     fn draw_polygon(
         &mut self,
-        &[cgmath::Point2<i32>],
+        _: &[cgmath::Point2<i32>],
         fill: bool,
         c: common::color,
     ) -> common::mxcfb_rect;

--- a/src/framebuffer/mxcfb.rs
+++ b/src/framebuffer/mxcfb.rs
@@ -1,5 +1,3 @@
-#![allow(non_camel_case_types)]
-
 use libc::intptr_t;
 
 use crate::framebuffer::common::mxcfb_rect;

--- a/src/framebuffer/mxcfb.rs
+++ b/src/framebuffer/mxcfb.rs
@@ -3,7 +3,7 @@
 use libc;
 use libc::intptr_t;
 
-use framebuffer::common::mxcfb_rect;
+use crate::framebuffer::common::mxcfb_rect;
 
 #[derive(Debug)]
 #[repr(C)]

--- a/src/framebuffer/mxcfb.rs
+++ b/src/framebuffer/mxcfb.rs
@@ -1,6 +1,5 @@
 #![allow(non_camel_case_types)]
 
-use libc;
 use libc::intptr_t;
 
 use crate::framebuffer::common::mxcfb_rect;

--- a/src/framebuffer/refresh.rs
+++ b/src/framebuffer/refresh.rs
@@ -3,10 +3,10 @@ use libc;
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::Ordering;
 
-use framebuffer;
-use framebuffer::common;
-use framebuffer::core;
-use framebuffer::mxcfb::*;
+use crate::framebuffer;
+use crate::framebuffer::common;
+use crate::framebuffer::core;
+use crate::framebuffer::mxcfb::*;
 
 pub enum PartialRefreshMode {
     DryRun,

--- a/src/framebuffer/refresh.rs
+++ b/src/framebuffer/refresh.rs
@@ -79,8 +79,8 @@ impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
         let mut update_region = region.to_owned();
 
         // No accounting for this, out of bounds, entirely ignored
-        if update_region.left >= u32::from(self.var_screen_info.xres)
-            || update_region.top >= u32::from(self.var_screen_info.yres)
+        if update_region.left >= self.var_screen_info.xres
+            || update_region.top >= self.var_screen_info.yres
         {
             return 0;
         }
@@ -94,14 +94,14 @@ impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
 
         // Dont try to refresh OOB horizontally
         let max_x = update_region.left + update_region.width;
-        if max_x > u32::from(self.var_screen_info.xres) {
-            update_region.width -= max_x - u32::from(self.var_screen_info.xres);
+        if max_x > self.var_screen_info.xres {
+            update_region.width -= max_x - self.var_screen_info.xres;
         }
 
         // Dont try to refresh OOB vertically
         let max_y = update_region.top + update_region.height;
-        if max_y > u32::from(self.var_screen_info.yres) {
-            update_region.height -= max_y - u32::from(self.var_screen_info.yres);
+        if max_y > self.var_screen_info.yres {
+            update_region.height -= max_y - self.var_screen_info.yres;
         }
 
         let update_mode = if force_full_refresh {

--- a/src/framebuffer/refresh.rs
+++ b/src/framebuffer/refresh.rs
@@ -1,6 +1,8 @@
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::Ordering;
 
+use log::warn;
+
 use crate::framebuffer;
 use crate::framebuffer::common;
 use crate::framebuffer::core;

--- a/src/framebuffer/refresh.rs
+++ b/src/framebuffer/refresh.rs
@@ -1,5 +1,3 @@
-use libc;
-
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::Ordering;
 

--- a/src/framebuffer/storage.rs
+++ b/src/framebuffer/storage.rs
@@ -1,5 +1,4 @@
 use std::sync::Arc;
-use zstd;
 
 #[derive(Clone)]
 pub struct CompressedCanvasState {
@@ -40,7 +39,6 @@ impl CompressedCanvasState {
 }
 
 use crate::framebuffer::common;
-use image;
 
 pub fn rgbimage_from_u8_slice(w: u32, h: u32, buff: &[u8]) -> Option<image::RgbImage> {
     // rgb565 is the input so it is 16bits (2 bytes) per pixel

--- a/src/framebuffer/storage.rs
+++ b/src/framebuffer/storage.rs
@@ -39,7 +39,7 @@ impl CompressedCanvasState {
     }
 }
 
-use framebuffer::common;
+use crate::framebuffer::common;
 use image;
 
 pub fn rgbimage_from_u8_slice(w: u32, h: u32, buff: &[u8]) -> Option<image::RgbImage> {

--- a/src/input/ecodes.rs
+++ b/src/input/ecodes.rs
@@ -1,43 +1,41 @@
 // Used event codes (input events as standardized in the linux kernel)
 // See https://github.com/torvalds/linux/blob/master/include/uapi/linux/input-event-codes.h
 
-
 // Event types
-pub const EV_SYN: u16             = 0x00;
-pub const EV_KEY: u16             = 0x01; // BTN prefixed constants are of type EV_KEY, too
-pub const EV_ABS: u16             = 0x03;
+pub const EV_SYN: u16 = 0x00;
+pub const EV_KEY: u16 = 0x01; // BTN prefixed constants are of type EV_KEY, too
+pub const EV_ABS: u16 = 0x03;
 
 // Syn events seem to be used for syncing and configuring the events themselves
-pub const SYN_REPORT: u16       = 0x00;
+pub const SYN_REPORT: u16 = 0x00;
 // SYN_CONFIG, MT_REPORT, SYN_DROPPED, SYN_MAX, SYN_CNT
 
-
 // Absolute Multitouch (Touchpad on reMarkable)
-pub const ABS_MT_SLOT:        u16 = 0x2f; // = 47
+pub const ABS_MT_SLOT: u16 = 0x2f; // = 47
 pub const ABS_MT_TOUCH_MAJOR: u16 = 0x30; // = 48
 pub const ABS_MT_TOUCH_MINOR: u16 = 0x31; // = 49
 pub const ABS_MT_ORIENTATION: u16 = 0x34; // = 52
-pub const ABS_MT_POSITION_X:  u16 = 0x35; // = 53
-pub const ABS_MT_POSITION_Y:  u16 = 0x36; // = 54
+pub const ABS_MT_POSITION_X: u16 = 0x35; // = 53
+pub const ABS_MT_POSITION_Y: u16 = 0x36; // = 54
 pub const ABS_MT_TRACKING_ID: u16 = 0x39; // = 57
-pub const ABS_MT_PRESSURE:    u16 = 0x3a; // = 58
-// Absolute (Wacom Digitizer on reMarkable)
-pub const ABS_PRESSURE:       u16 = 0x18; // = 24
-pub const ABS_DISTANCE:       u16 = 0x19; // = 25
-pub const ABS_TILT_X:         u16 = 0x1a; // = 26
-pub const ABS_TILT_Y:         u16 = 0x1b; // = 27
-pub const ABS_X:              u16 = 0x00; // = 0
-pub const ABS_Y:              u16 = 0x01; // = 1
+pub const ABS_MT_PRESSURE: u16 = 0x3a; // = 58
+                                       // Absolute (Wacom Digitizer on reMarkable)
+pub const ABS_PRESSURE: u16 = 0x18; // = 24
+pub const ABS_DISTANCE: u16 = 0x19; // = 25
+pub const ABS_TILT_X: u16 = 0x1a; // = 26
+pub const ABS_TILT_Y: u16 = 0x1b; // = 27
+pub const ABS_X: u16 = 0x00; // = 0
+pub const ABS_Y: u16 = 0x01; // = 1
 
 // Keys (Wacom Digitizer buttons on reMarkable)
-pub const BTN_TOOL_PEN:       u16 = 0x140; // = 320
-pub const BTN_TOOL_RUBBER:    u16 = 0x141; // = 321
-pub const BTN_TOUCH:          u16 = 0x14a; // = 330
-pub const BTN_STYLUS:         u16 = 0x14b; // = 331
-pub const BTN_STYLUS2:        u16 = 0x14c; // = 332
-// Keys (GPIOs on reMarkable)
-pub const KEY_HOME:          u16 = 0x66; // = 102 (aka middle button on the reMarkable)
-pub const KEY_LEFT:          u16 = 0x69; // = 105
-pub const KEY_RIGHT:         u16 = 0x6a; // = 106
-pub const KEY_POWER:         u16 = 0x74; // = 116
-pub const KEY_WAKEUP:        u16 = 0x8f; // = 143
+pub const BTN_TOOL_PEN: u16 = 0x140; // = 320
+pub const BTN_TOOL_RUBBER: u16 = 0x141; // = 321
+pub const BTN_TOUCH: u16 = 0x14a; // = 330
+pub const BTN_STYLUS: u16 = 0x14b; // = 331
+pub const BTN_STYLUS2: u16 = 0x14c; // = 332
+                                    // Keys (GPIOs on reMarkable)
+pub const KEY_HOME: u16 = 0x66; // = 102 (aka middle button on the reMarkable)
+pub const KEY_LEFT: u16 = 0x69; // = 105
+pub const KEY_RIGHT: u16 = 0x6a; // = 106
+pub const KEY_POWER: u16 = 0x74; // = 116
+pub const KEY_WAKEUP: u16 = 0x8f; // = 143

--- a/src/input/ev.rs
+++ b/src/input/ev.rs
@@ -1,6 +1,6 @@
+use crate::input;
 use epoll;
 use evdev;
-use input;
 use std;
 
 use std::sync::atomic::{AtomicBool, Ordering};

--- a/src/input/ev.rs
+++ b/src/input/ev.rs
@@ -97,24 +97,33 @@ impl EvDevContext {
                                 input::InputDevice::Multitouch => {
                                     for event in input::multitouch::decode(&ev, &state) {
                                         if let Err(e) = tx.send(event) {
-                                            error!("Failed to write InputEvent into the channel: {}", e);
+                                            error!(
+                                                "Failed to write InputEvent into the channel: {}",
+                                                e
+                                            );
                                         }
                                     }
-                                },
+                                }
                                 input::InputDevice::Wacom => {
                                     if let Some(event) = input::wacom::decode(&ev, &state) {
                                         if let Err(e) = tx.send(event) {
-                                            error!("Failed to write InputEvent into the channel: {}", e);
+                                            error!(
+                                                "Failed to write InputEvent into the channel: {}",
+                                                e
+                                            );
                                         }
                                     }
-                                },
+                                }
                                 input::InputDevice::GPIO => {
                                     if let Some(event) = input::gpio::decode(&ev, &state) {
                                         if let Err(e) = tx.send(event) {
-                                            error!("Failed to write InputEvent into the channel: {}", e);
+                                            error!(
+                                                "Failed to write InputEvent into the channel: {}",
+                                                e
+                                            );
                                         }
                                     }
-                                },
+                                }
                                 _ => unreachable!(),
                             };
                         }

--- a/src/input/ev.rs
+++ b/src/input/ev.rs
@@ -1,7 +1,4 @@
 use crate::input;
-use epoll;
-use evdev;
-use std;
 
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;

--- a/src/input/ev.rs
+++ b/src/input/ev.rs
@@ -1,5 +1,7 @@
 use crate::input;
 
+use log::{error, info, warn};
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 

--- a/src/input/gpio.rs
+++ b/src/input/gpio.rs
@@ -1,6 +1,7 @@
 use super::ecodes;
 use crate::input::{InputDeviceState, InputEvent};
 use evdev::raw::input_event;
+use log::error;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 #[derive(PartialEq, Copy, Clone)]

--- a/src/input/gpio.rs
+++ b/src/input/gpio.rs
@@ -1,7 +1,7 @@
+use super::ecodes;
 use evdev::raw::input_event;
 use input::{InputDeviceState, InputEvent};
 use std::sync::atomic::{AtomicBool, Ordering};
-use super::ecodes;
 
 #[derive(PartialEq, Copy, Clone)]
 pub enum PhysicalButton {

--- a/src/input/gpio.rs
+++ b/src/input/gpio.rs
@@ -1,6 +1,6 @@
 use super::ecodes;
+use crate::input::{InputDeviceState, InputEvent};
 use evdev::raw::input_event;
-use input::{InputDeviceState, InputEvent};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 #[derive(PartialEq, Copy, Clone)]

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -28,7 +28,6 @@ pub enum InputDeviceState {
     GPIOState(std::sync::Arc<gpio::GPIOState>),
 }
 
-use std;
 use std::sync::Arc;
 impl Clone for InputDeviceState {
     fn clone(&self) -> InputDeviceState {

--- a/src/input/multitouch.rs
+++ b/src/input/multitouch.rs
@@ -89,23 +89,17 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Vec<InputEven
                             finger.last_pressed = finger.pressed;
 
                             events.push(InputEvent::MultitouchEvent {
-                                event: MultitouchEvent::Press {
-                                    finger: finger.clone(),
-                                },
+                                event: MultitouchEvent::Press { finger: *finger },
                             });
                         } else if finger.last_pressed && !finger.pressed {
                             // Released
                             finger.last_pressed = finger.pressed;
                             events.push(InputEvent::MultitouchEvent {
-                                event: MultitouchEvent::Release {
-                                    finger: finger.clone(),
-                                },
+                                event: MultitouchEvent::Release { finger: *finger },
                             });
                         } else if finger.last_pressed && finger.pressed && finger.pos_updated {
                             events.push(InputEvent::MultitouchEvent {
-                                event: MultitouchEvent::Move {
-                                    finger: finger.clone(),
-                                },
+                                event: MultitouchEvent::Move { finger: *finger },
                             });
                         }
 

--- a/src/input/multitouch.rs
+++ b/src/input/multitouch.rs
@@ -1,10 +1,10 @@
-use framebuffer::cgmath;
-use framebuffer::common::{DISPLAYHEIGHT, DISPLAYWIDTH, MTHEIGHT, MTWIDTH};
+use crate::framebuffer::cgmath;
+use crate::framebuffer::common::{DISPLAYHEIGHT, DISPLAYWIDTH, MTHEIGHT, MTWIDTH};
 
 use super::ecodes;
+use crate::input::{InputDeviceState, InputEvent};
 use evdev::raw::input_event;
 use fxhash::FxHashMap;
-use input::{InputDeviceState, InputEvent};
 use std::sync::{
     atomic::{AtomicI32, Ordering},
     Mutex,

--- a/src/input/multitouch.rs
+++ b/src/input/multitouch.rs
@@ -5,6 +5,7 @@ use super::ecodes;
 use crate::input::{InputDeviceState, InputEvent};
 use evdev::raw::input_event;
 use fxhash::FxHashMap;
+use log::{debug, warn};
 use std::sync::{
     atomic::{AtomicI32, Ordering},
     Mutex,

--- a/src/input/wacom.rs
+++ b/src/input/wacom.rs
@@ -1,12 +1,12 @@
 use super::ecodes;
+use crate::input::{InputDeviceState, InputEvent};
 use atomic::Atomic;
 use evdev::raw::input_event;
-use input::{InputDeviceState, InputEvent};
 use std;
 use std::sync::atomic::{AtomicU16, Ordering};
 
-use framebuffer::cgmath;
-use framebuffer::common::{DISPLAYHEIGHT, DISPLAYWIDTH, WACOMHEIGHT, WACOMWIDTH};
+use crate::framebuffer::cgmath;
+use crate::framebuffer::common::{DISPLAYHEIGHT, DISPLAYWIDTH, WACOMHEIGHT, WACOMWIDTH};
 
 const WACOM_HSCALAR: f32 = (DISPLAYWIDTH as f32) / (WACOMWIDTH as f32);
 const WACOM_VSCALAR: f32 = (DISPLAYHEIGHT as f32) / (WACOMHEIGHT as f32);

--- a/src/input/wacom.rs
+++ b/src/input/wacom.rs
@@ -2,7 +2,6 @@ use super::ecodes;
 use crate::input::{InputDeviceState, InputEvent};
 use atomic::Atomic;
 use evdev::raw::input_event;
-use std;
 use std::sync::atomic::{AtomicU16, Ordering};
 
 use crate::framebuffer::cgmath;

--- a/src/input/wacom.rs
+++ b/src/input/wacom.rs
@@ -2,6 +2,7 @@ use super::ecodes;
 use crate::input::{InputDeviceState, InputEvent};
 use atomic::Atomic;
 use evdev::raw::input_event;
+use log::debug;
 use std::sync::atomic::{AtomicU16, Ordering};
 
 use crate::framebuffer::cgmath;

--- a/src/input/wacom.rs
+++ b/src/input/wacom.rs
@@ -1,9 +1,9 @@
+use super::ecodes;
 use atomic::Atomic;
 use evdev::raw::input_event;
 use input::{InputDeviceState, InputEvent};
 use std;
 use std::sync::atomic::{AtomicU16, Ordering};
-use super::ecodes;
 
 use framebuffer::cgmath;
 use framebuffer::common::{DISPLAYHEIGHT, DISPLAYWIDTH, WACOMHEIGHT, WACOMWIDTH};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ macro_rules! end_bench {
     ($name:ident) => {
         let dur = $name.elapsed();
         let s = dur.as_secs();
-        let mut us = dur.subsec_nanos() / 1000;
+        let mut us = dur.subsec_micros();
         let ms = us / 1000;
         us -= ms * 1000;
         println!("'{}' took {}s {}ms {}us", stringify!($name), s, ms, us);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(integer_atomics)]
-#![feature(box_syntax)]
 #![feature(nll)]
 
 #[cfg(not(feature = "enable-runtime-benchmarking"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![feature(integer_atomics)]
-
 #[cfg(not(feature = "enable-runtime-benchmarking"))]
 #[macro_export]
 macro_rules! start_bench {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,21 +41,12 @@ extern crate log;
 #[macro_use]
 extern crate ioctl_gen;
 
-extern crate aabb_quadtree;
-extern crate atomic;
-extern crate fxhash;
-extern crate hlua;
-extern crate libc;
-extern crate mmap;
-extern crate rusttype;
-extern crate zstd;
-
-pub extern crate cgmath;
-pub extern crate epoll;
-pub extern crate evdev;
-pub extern crate image;
-pub extern crate line_drawing;
-pub extern crate stopwatch;
+pub use cgmath;
+pub use epoll;
+pub use evdev;
+pub use image;
+pub use line_drawing;
+pub use stopwatch;
 
 /// One of the core components, allowing output and refresh of the EInk display
 pub mod framebuffer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,9 +36,6 @@ macro_rules! end_bench {
 }
 
 #[macro_use]
-extern crate log;
-
-#[macro_use]
 extern crate ioctl_gen;
 
 pub use cgmath;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![feature(integer_atomics)]
-#![feature(nll)]
 
 #[cfg(not(feature = "enable-runtime-benchmarking"))]
 #[macro_export]

--- a/src/ui_extensions/element.rs
+++ b/src/ui_extensions/element.rs
@@ -4,14 +4,14 @@ use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
 
 use image;
 
-use framebuffer::cgmath;
-use framebuffer::common;
-use framebuffer::common::{color, mxcfb_rect};
-use framebuffer::refresh::PartialRefreshMode;
-use framebuffer::FramebufferDraw;
-use framebuffer::FramebufferRefresh;
+use crate::framebuffer::cgmath;
+use crate::framebuffer::common;
+use crate::framebuffer::common::{color, mxcfb_rect};
+use crate::framebuffer::refresh::PartialRefreshMode;
+use crate::framebuffer::FramebufferDraw;
+use crate::framebuffer::FramebufferRefresh;
 
-use appctx;
+use crate::appctx;
 
 pub type ActiveRegionFunction = fn(&mut appctx::ApplicationContext, UIElementHandle);
 

--- a/src/ui_extensions/element.rs
+++ b/src/ui_extensions/element.rs
@@ -13,7 +13,7 @@ use crate::framebuffer::FramebufferRefresh;
 
 use crate::appctx;
 
-pub type ActiveRegionFunction = fn(&mut appctx::ApplicationContext, UIElementHandle);
+pub type ActiveRegionFunction = fn(&mut appctx::ApplicationContext<'_>, UIElementHandle);
 
 #[derive(Clone)]
 pub struct ActiveRegionHandler {
@@ -22,7 +22,7 @@ pub struct ActiveRegionHandler {
 }
 
 impl<'a> std::fmt::Debug for ActiveRegionHandler {
-    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{0:p}", self)
     }
 }
@@ -99,11 +99,11 @@ pub enum UIElement {
 }
 
 impl UIElementHandle {
-    pub fn read(&self) -> RwLockReadGuard<UIElementWrapper> {
+    pub fn read(&self) -> RwLockReadGuard<'_, UIElementWrapper> {
         self.0.read().unwrap()
     }
 
-    pub fn write(&self) -> RwLockWriteGuard<UIElementWrapper> {
+    pub fn write(&self) -> RwLockWriteGuard<'_, UIElementWrapper> {
         self.0.write().unwrap()
     }
 
@@ -115,7 +115,7 @@ impl UIElementHandle {
 impl UIElementWrapper {
     pub fn draw(
         &mut self,
-        app: &mut appctx::ApplicationContext,
+        app: &mut appctx::ApplicationContext<'_>,
         handler: &Option<ActiveRegionHandler>,
     ) {
         let refresh = self.refresh;

--- a/src/ui_extensions/element.rs
+++ b/src/ui_extensions/element.rs
@@ -1,8 +1,5 @@
-use std;
 use std::hash::{Hash, Hasher};
 use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
-
-use image;
 
 use crate::framebuffer::cgmath;
 use crate::framebuffer::common;

--- a/src/ui_extensions/luaext.rs
+++ b/src/ui_extensions/luaext.rs
@@ -1,15 +1,15 @@
 use hlua;
 use std;
 
-use framebuffer::cgmath;
-use framebuffer::common::*;
-use framebuffer::core;
+use crate::framebuffer::cgmath;
+use crate::framebuffer::common::*;
+use crate::framebuffer::core;
 
-use framebuffer::refresh::PartialRefreshMode;
+use crate::framebuffer::refresh::PartialRefreshMode;
 
-use framebuffer::FramebufferDraw;
-use framebuffer::FramebufferIO;
-use framebuffer::FramebufferRefresh;
+use crate::framebuffer::FramebufferDraw;
+use crate::framebuffer::FramebufferIO;
+use crate::framebuffer::FramebufferRefresh;
 
 /// We reluctantly resort to a static global here to associate the lua context
 /// with the only active framebuffer we will have

--- a/src/ui_extensions/luaext.rs
+++ b/src/ui_extensions/luaext.rs
@@ -1,6 +1,3 @@
-use hlua;
-use std;
-
 use crate::framebuffer::cgmath;
 use crate::framebuffer::common::*;
 use crate::framebuffer::core;

--- a/src/ui_extensions/luaext.rs
+++ b/src/ui_extensions/luaext.rs
@@ -13,12 +13,12 @@ use crate::framebuffer::FramebufferRefresh;
 
 /// We reluctantly resort to a static global here to associate the lua context
 /// with the only active framebuffer we will have
-pub static mut G_FB: *mut core::Framebuffer = std::ptr::null_mut();
+pub static mut G_FB: *mut core::Framebuffer<'_> = std::ptr::null_mut();
 
 /// A macro to utilize this static global only inside this file.
 macro_rules! get_current_framebuffer {
     () => {
-        unsafe { &mut *(G_FB as *mut core::Framebuffer) }
+        unsafe { &mut *(G_FB as *mut core::Framebuffer<'_>) }
     };
 }
 


### PR DESCRIPTION
This is a PR that updates the codebase to Rust 2018 editions idioms. It also does a few more cleanups I thought make sense. I wanted to make other change to libremarkable, but I'm so used to Rust 2018 edition codebases, hence this PR.

@canselcik please see this as a proposal. I intentionally tried to keep the commits small and self contained, so that you can decide if there are changes you don't like. I'm happy to rebase things and removing stuff or making other changes.

One issue is that `ioctl-gen` cannot be used with normal imports. I've created https://github.com/quadrupleslap-old/ioctl-gen/pull/1 to fix this. For now I've put my branch into Cargo.toml, that of course needs to be resolved before merging.

The demo application still works on my device.