### PR TITLE
Fix gpio and add input example

### DIFF
--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,0 +1,16 @@
+use libremarkable::input::{ev::EvDevContext, InputDevice, InputEvent};
+use std::sync::mpsc::channel;
+
+fn main() {
+    // Send all input events to input_rx
+    let (input_tx, input_rx) = channel::<InputEvent>();
+    EvDevContext::new(InputDevice::GPIO, input_tx.clone()).start();
+    EvDevContext::new(InputDevice::Multitouch, input_tx.clone()).start();
+    EvDevContext::new(InputDevice::Wacom, input_tx).start();
+
+    eprintln!("Waiting for input events...");
+    while let Ok(event) = input_rx.recv() {
+        println!("{:?}", event);
+    }
+    eprintln!("All event loops were closed?!?");
+}

--- a/src/input/gpio.rs
+++ b/src/input/gpio.rs
@@ -4,7 +4,7 @@ use evdev::raw::input_event;
 use log::error;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub enum PhysicalButton {
     LEFT,
     MIDDLE,
@@ -13,7 +13,7 @@ pub enum PhysicalButton {
     WAKEUP,
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub enum GPIOEvent {
     Press { button: PhysicalButton },
     Unpress { button: PhysicalButton },

--- a/src/input/gpio.rs
+++ b/src/input/gpio.rs
@@ -49,37 +49,31 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Option<InputE
             None
         }
         ecodes::EV_KEY => {
-            let (p, before_state) = match ev.code {
-                ecodes::KEY_HOME => (
-                    PhysicalButton::MIDDLE,
-                    state.states[0].fetch_and(ev.value != 0, Ordering::Relaxed),
-                ),
-                ecodes::KEY_LEFT => (
-                    PhysicalButton::LEFT,
-                    state.states[1].fetch_and(ev.value != 0, Ordering::Relaxed),
-                ),
-                ecodes::KEY_RIGHT => (
-                    PhysicalButton::RIGHT,
-                    state.states[2].fetch_and(ev.value != 0, Ordering::Relaxed),
-                ),
-                ecodes::KEY_POWER => (
-                    PhysicalButton::POWER,
-                    state.states[3].fetch_and(ev.value != 0, Ordering::Relaxed),
-                ),
-                ecodes::KEY_WAKEUP => (
-                    PhysicalButton::WAKEUP,
-                    state.states[4].fetch_and(ev.value != 0, Ordering::Relaxed),
-                ),
+            let p = match ev.code {
+                ecodes::KEY_HOME => {
+                    state.states[0].store(ev.value != 0, Ordering::Relaxed);
+                    PhysicalButton::MIDDLE
+                }
+                ecodes::KEY_LEFT => {
+                    state.states[1].store(ev.value != 0, Ordering::Relaxed);
+                    PhysicalButton::LEFT
+                }
+                ecodes::KEY_RIGHT => {
+                    state.states[2].store(ev.value != 0, Ordering::Relaxed);
+                    PhysicalButton::RIGHT
+                }
+                ecodes::KEY_POWER => {
+                    state.states[3].store(ev.value != 0, Ordering::Relaxed);
+                    PhysicalButton::POWER
+                }
+                ecodes::KEY_WAKEUP => {
+                    state.states[4].store(ev.value != 0, Ordering::Relaxed);
+                    PhysicalButton::WAKEUP
+                }
                 _ => return None,
             };
 
-            // Edge trigger -- debouncing
-            let new_state = ev.value != 0;
-            if new_state == before_state {
-                return None;
-            }
-
-            let event = if new_state {
+            let event = if ev.value != 0 {
                 GPIOEvent::Press { button: p }
             } else {
                 GPIOEvent::Unpress { button: p }

--- a/src/input/gpio.rs
+++ b/src/input/gpio.rs
@@ -44,11 +44,11 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Option<InputE
         _ => unreachable!(),
     };
     match ev._type {
-        0 => {
+        ecodes::EV_SYN => {
             /* safely ignored. sync event*/
             None
         }
-        1 => {
+        ecodes::EV_KEY => {
             let (p, before_state) = match ev.code {
                 ecodes::KEY_HOME => (
                     PhysicalButton::MIDDLE,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -60,7 +60,7 @@ impl InputDeviceState {
     }
 }
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum InputEvent {
     WacomEvent { event: wacom::WacomEvent },
     MultitouchEvent { event: multitouch::MultitouchEvent },

--- a/src/input/multitouch.rs
+++ b/src/input/multitouch.rs
@@ -53,7 +53,7 @@ impl ::std::default::Default for MultitouchState {
     }
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub enum MultitouchEvent {
     Press { finger: Finger },
     Release { finger: Finger },

--- a/src/input/wacom.rs
+++ b/src/input/wacom.rs
@@ -51,7 +51,7 @@ pub enum WacomPen {
     Stylus2 = ecodes::BTN_STYLUS2,
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub enum WacomEventType {
     InstrumentChange,
     Hover,
@@ -59,7 +59,7 @@ pub enum WacomEventType {
     Unknown,
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub enum WacomEvent {
     InstrumentChange {
         pen: WacomPen,


### PR DESCRIPTION
Hi,

I'm currently on adding rm2 support to the input system. At first I added a `examples/input.rs` to debug differences and noticed that the `GPIOEvent::Unpress` never happened.

I decided to make this a separate PR since it doesn't add any rM2 updates, yet. It does 2 things however:
- Add the Debug trait to all InputEvent related structs
- Add an `input` example which simply prints the debug information of all input events (similar to evtest)
- Remove the GPIO debouncing to get the Unpress-Event to work

(This PR will probably be followed by one for the rM2 support shortly.)