### PR TITLE
reMarkable 2 input support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ ioctl-gen = "0.1.1"
 libc = "0.2.69"
 mmap = "0.1.1"
 rusttype = "0.8.2"
-evdev = "0.10.1"
+evdev = { git = "https://github.com/LinusCDE/evdev.git", rev = "43fb0b33994dba667ab3f1c107b7393ac3166ffe" }
 epoll = "4.1.0"
 image = "0.21.3"
 line_drawing = "0.8.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,7 @@ stopwatch = "0.0.7"
 atomic = { version = "0.5.0" }
 cgmath = "0.17.0"
 fxhash = "0.2.1"
+lazy_static = "1.4.0"
 
 [features]
 enable-runtime-benchmarking = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,6 @@ zstd = "0.5.1"
 stopwatch = "0.0.7"
 atomic = { version = "0.5.0" }
 cgmath = "0.17.0"
-fxhash = "0.2.1"
 lazy_static = "1.4.0"
 
 [features]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ zstd = "0.5.1"
 stopwatch = "0.0.7"
 atomic = { version = "0.5.0" }
 cgmath = "0.17.0"
+fxhash = "0.2.1"
 lazy_static = "1.4.0"
 
 [features]

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,7 +1,18 @@
-use libremarkable::input::{ev::EvDevContext, InputDevice, InputEvent};
+use libremarkable::input::{ev::EvDevContext, ev::INPUT_DEVICE_PATHS, InputDevice, InputEvent};
 use std::sync::mpsc::channel;
 
 fn main() {
+    // Display paths for InputDevices
+    for device in [
+        InputDevice::GPIO,
+        InputDevice::Multitouch,
+        InputDevice::Wacom,
+    ]
+    .iter()
+    {
+        eprintln!("{:?} is {:?}", INPUT_DEVICE_PATHS[device], device);
+    }
+
     // Send all input events to input_rx
     let (input_tx, input_rx) = channel::<InputEvent>();
     EvDevContext::new(InputDevice::GPIO, input_tx.clone()).start();

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,4 +1,4 @@
-use libremarkable::input::{ev::EvDevContext, ev::INPUT_DEVICE_PATHS, InputDevice, InputEvent};
+use libremarkable::input::{ev::EvDevContext, scan::SCAN, InputDevice, InputEvent};
 use std::sync::mpsc::channel;
 
 fn main() {
@@ -10,7 +10,7 @@ fn main() {
     ]
     .iter()
     {
-        eprintln!("{:?} is {:?}", INPUT_DEVICE_PATHS[device], device);
+        eprintln!("{:?} is {:?}", SCAN.get_path(*device), device);
     }
 
     // Send all input events to input_rx

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,3 +1,4 @@
+use libremarkable::framebuffer::common::{MTHEIGHT, MTWIDTH, WACOMHEIGHT, WACOMWIDTH};
 use libremarkable::input::{ev::EvDevContext, scan::SCAN, InputDevice, InputEvent};
 use std::sync::mpsc::channel;
 
@@ -12,6 +13,9 @@ fn main() {
     {
         eprintln!("{:?} is {:?}", SCAN.get_path(*device), device);
     }
+
+    eprintln!("Multitouch resolution: {}x{}", *MTWIDTH, *MTHEIGHT);
+    eprintln!("Wacom resolution: {}x{}", *WACOMWIDTH, *WACOMHEIGHT);
 
     // Send all input events to input_rx
     let (input_tx, input_rx) = channel::<InputEvent>();

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,0 +1,16 @@
+use libremarkable::input::{ev::EvDevContext, InputDevice, InputEvent};
+use std::sync::mpsc::channel;
+
+fn main() {
+    // Send all input events to input_rx
+    let (input_tx, input_rx) = channel::<InputEvent>();
+    EvDevContext::new(InputDevice::GPIO, input_tx.clone()).start();
+    EvDevContext::new(InputDevice::Multitouch, input_tx.clone()).start();
+    EvDevContext::new(InputDevice::Wacom, input_tx).start();
+
+    eprintln!("Waiting for input events...");
+    while let Ok(event) = input_rx.recv() {
+        println!("{:?}", event);
+    }
+    eprintln!("All event loops were closed?!?");
+}

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -3,6 +3,9 @@ use libremarkable::input::{ev::EvDevContext, scan::SCAN, InputDevice, InputEvent
 use std::sync::mpsc::channel;
 
 fn main() {
+    // Measure start time
+    let start = std::time::SystemTime::now();
+
     // Display paths for InputDevices
     for device in [
         InputDevice::GPIO,
@@ -22,6 +25,9 @@ fn main() {
     EvDevContext::new(InputDevice::GPIO, input_tx.clone()).start();
     EvDevContext::new(InputDevice::Multitouch, input_tx.clone()).start();
     EvDevContext::new(InputDevice::Wacom, input_tx).start();
+
+    // Output measurement of start time
+    eprintln!("Opened input devices in {:?}", start.elapsed().unwrap());
 
     eprintln!("Waiting for input events...");
     while let Ok(event) = input_rx.recv() {

--- a/examples/input.rs
+++ b/examples/input.rs
@@ -1,5 +1,5 @@
 use libremarkable::framebuffer::common::{MTHEIGHT, MTWIDTH, WACOMHEIGHT, WACOMWIDTH};
-use libremarkable::input::{ev::EvDevContext, scan::SCAN, InputDevice, InputEvent};
+use libremarkable::input::{ev::EvDevContext, scan::SCANNED, InputDevice, InputEvent};
 use std::sync::mpsc::channel;
 
 fn main() {
@@ -14,7 +14,7 @@ fn main() {
     ]
     .iter()
     {
-        eprintln!("{:?} is {:?}", SCAN.get_path(*device), device);
+        eprintln!("{:?} is {:?}", SCANNED.get_path(*device), device);
     }
 
     eprintln!("Multitouch resolution: {}x{}", *MTWIDTH, *MTHEIGHT);

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,0 +1,54 @@
+#[derive(Debug, Copy, Clone, Eq, PartialEq)]
+pub enum Model {
+    Gen1,
+    Gen2,
+    Unknown,
+}
+
+impl std::fmt::Display for Model {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match *self {
+            Model::Gen1 => write!(f, "reMarkable 1"),
+            Model::Gen2 => write!(f, "reMarkable 2"),
+            Model::Unknown => write!(f, "Unknown reMarkable"),
+        }
+    }
+}
+
+impl Model {
+    fn current_model() -> std::io::Result<Model> {
+        let content = std::fs::read_to_string("/sys/devices/soc0/machine")?;
+        if content.contains('1') && !content.contains(".1") {
+            return Ok(Model::Gen1);
+        } else if content.contains('2') && !content.contains(".2") {
+            return Ok(Model::Gen2);
+        } else {
+            return Ok(Model::Unknown);
+        }
+    }
+}
+
+lazy_static! {
+    pub static ref DEVICE: Device = Device::new();
+}
+
+/// Mainly information regarding both models
+pub struct Device {
+    model: Model,
+}
+
+impl Device {
+    fn new() -> Self {
+        let model = Model::current_model()
+            .unwrap_or_else(|e| panic!("Got IO Error when determining model: {}", e));
+        if model == Model::Unknown {
+            panic!("Failed to determine model!");
+        }
+
+        Self { model: model }
+    }
+
+    pub fn get_model(&self) -> Model {
+        self.model
+    }
+}

--- a/src/device.rs
+++ b/src/device.rs
@@ -50,7 +50,7 @@ impl Device {
             panic!("Failed to determine model!");
         }
 
-        Self { model: model }
+        Self { model }
     }
 
     pub fn get_multitouch_rotation(&self) -> InputDeviceRotation {

--- a/src/device.rs
+++ b/src/device.rs
@@ -57,7 +57,7 @@ impl Device {
         match self.model {
             Model::Gen1 => InputDeviceRotation::Rot180,
             Model::Gen2 => InputDeviceRotation::Rot270,
-            Model::Unknown => InputDeviceRotation::Rot180, // Assumtion!
+            Model::Unknown => unreachable!(),
         }
     }
 

--- a/src/framebuffer/common.rs
+++ b/src/framebuffer/common.rs
@@ -1,7 +1,7 @@
 #![allow(non_camel_case_types)]
 use crate::framebuffer::cgmath;
 use crate::framebuffer::mxcfb::*;
-use crate::input::scan::SCAN;
+use crate::input::scan::SCANNED;
 
 /// This is to allow tests to run on systems with 64bit pointer types.
 /// It doesn't make a difference since we will be mocking the ioctl calls.
@@ -17,14 +17,14 @@ pub const DISPLAYHEIGHT: u16 = 1872;
 
 lazy_static! {
     /// Will be 767 rM1 and 1403 on the rM2
-    pub static ref MTWIDTH: u16 = SCAN.mt_width;
+    pub static ref MTWIDTH: u16 = SCANNED.mt_width;
     /// Will be 1023 the rM1 and 1871 on the rM2
-    pub static ref MTHEIGHT: u16 = SCAN.mt_height;
+    pub static ref MTHEIGHT: u16 = SCANNED.mt_height;
 
     /// Will be 15725 on both the rM1 and rM2
-    pub static ref WACOMWIDTH: u16 = SCAN.wacom_width;
+    pub static ref WACOMWIDTH: u16 = SCANNED.wacom_width;
     /// Will be 20967 on the rM1 and 20966 on the rM2
-    pub static ref WACOMHEIGHT: u16 = SCAN.wacom_height;
+    pub static ref WACOMHEIGHT: u16 = SCANNED.wacom_height;
 }
 
 pub const MXCFB_SET_AUTO_UPDATE_MODE: NativeWidthType =

--- a/src/framebuffer/common.rs
+++ b/src/framebuffer/common.rs
@@ -1,6 +1,7 @@
 #![allow(non_camel_case_types)]
 use crate::framebuffer::cgmath;
 use crate::framebuffer::mxcfb::*;
+use crate::input::scan::SCAN;
 
 /// This is to allow tests to run on systems with 64bit pointer types.
 /// It doesn't make a difference since we will be mocking the ioctl calls.
@@ -14,11 +15,17 @@ pub type NativeWidthType = u32;
 pub const DISPLAYWIDTH: u16 = 1404;
 pub const DISPLAYHEIGHT: u16 = 1872;
 
-pub const MTWIDTH: u16 = 767;
-pub const MTHEIGHT: u16 = 1023;
+lazy_static! {
+    /// Will be 767 rM1 and 1403 on the rM2
+    pub static ref MTWIDTH: u16 = SCAN.mt_width;
+    /// Will be 1023 the rM1 and 1871 on the rM2
+    pub static ref MTHEIGHT: u16 = SCAN.mt_height;
 
-pub const WACOMWIDTH: u16 = 15725;
-pub const WACOMHEIGHT: u16 = 20967;
+    /// Will be 15725 on both the rM1 and rM2
+    pub static ref WACOMWIDTH: u16 = SCAN.wacom_width;
+    /// Will be 20967 on the rM1 and 20966 on the rM2
+    pub static ref WACOMHEIGHT: u16 = SCAN.wacom_height;
+}
 
 pub const MXCFB_SET_AUTO_UPDATE_MODE: NativeWidthType =
     iow!(b'F', 0x2D, std::mem::size_of::<u32>()) as NativeWidthType;

--- a/src/input/ev.rs
+++ b/src/input/ev.rs
@@ -1,71 +1,9 @@
 use crate::input;
 
+use input::scan::SCAN;
 use log::{error, info, warn};
-
-use fxhash::FxHashMap;
-use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
-
-lazy_static! {
-    /// Map of what InputDevice has what event file path on the system.
-    /// The paths are different depending on the reMarkable model.
-    pub static ref INPUT_DEVICE_PATHS: FxHashMap<input::InputDevice, PathBuf> =
-        event_file_paths();
-}
-
-/// Returns a HashMap that contains the appropriate file paths for the InputDevices
-/// This way it'll always find the correct device no matter the device generation.
-/// Based on code by [@raisjn](https://github.com/raisjn): https://gist.github.com/raisjn/01b16286dcc4461a6643f40f8f553966
-fn event_file_paths() -> FxHashMap<input::InputDevice, PathBuf> {
-    let mut input_device_paths: FxHashMap<input::InputDevice, PathBuf> = FxHashMap::default();
-
-    // Get all /dev/input/event* file paths
-    let mut event_file_paths: Vec<PathBuf> = Vec::new();
-    let input_dir = Path::new("/dev/input");
-    for entry in input_dir
-        .read_dir()
-        .unwrap_or_else(|_| panic!("Failed to list {:?}", input_dir))
-    {
-        let entry = entry.unwrap();
-        let file_name = entry.file_name().as_os_str().to_str().unwrap().to_owned();
-        if !file_name.starts_with("event") {
-            continue;
-        }
-
-        let evdev_path = input_dir.join(&file_name);
-        event_file_paths.push(evdev_path);
-    }
-
-    // Open and check capabilities of each event device
-    for evdev_path in event_file_paths {
-        let dev = evdev::Device::open(&evdev_path)
-            .unwrap_or_else(|_| panic!("Failed to scan {:?}", &evdev_path));
-        if dev.events_supported().contains(evdev::KEY) {
-            if dev.keys_supported().contains(evdev::BTN_STYLUS as usize)
-                && dev.events_supported().contains(evdev::ABSOLUTE)
-            {
-                // The device with the wacom digitizer has the BTN_STYLUS event
-                // and support KEY as well as ABSOLUTE event types
-                input_device_paths.insert(input::InputDevice::Wacom, evdev_path.clone());
-            }
-
-            if dev.keys_supported().contains(evdev::KEY_POWER as usize) {
-                // The device for buttons has the KEY_POWER button and support KEY event types
-                input_device_paths.insert(input::InputDevice::GPIO, evdev_path.clone());
-            }
-        }
-
-        if dev.events_supported().contains(evdev::RELATIVE)
-            && dev.absolute_axes_supported().contains(evdev::ABS_MT_SLOT)
-        {
-            // The touchscreen device has the ABS_MT_SLOT event and supports RELATIVE event types
-            input_device_paths.insert(input::InputDevice::Multitouch, evdev_path.clone());
-        }
-    }
-
-    input_device_paths
-}
 
 pub struct EvDevContext {
     device: input::InputDevice,
@@ -111,16 +49,11 @@ impl EvDevContext {
 
     /// Non-blocking function that will open the provided path and wait for more data with epoll
     pub fn start(&mut self) {
-        if self.device == input::InputDevice::Unknown {
-            panic!("Invalid device (\"Unknown\")!");
-        }
-        let path = INPUT_DEVICE_PATHS[&self.device].clone();
-
         self.started.store(true, Ordering::Relaxed);
         self.exited.store(false, Ordering::Relaxed);
         self.exit_requested.store(false, Ordering::Relaxed);
 
-        match evdev::Device::open(&path) {
+        match SCAN.get_device(self.device) {
             Err(e) => error!("Error while reading events from epoll fd: {0}", e),
             Ok(mut dev) => {
                 let mut v = vec![epoll::Event {
@@ -134,7 +67,7 @@ impl EvDevContext {
                 epoll::ctl(epfd, epoll::ControlOptions::EPOLL_CTL_ADD, dev.fd(), v[0]).unwrap();
 
                 // init callback
-                info!("Init complete for {:?}", path);
+                info!("Init complete for {:?}", SCAN.get_path(self.device));
 
                 let exit_req = Arc::clone(&self.exit_requested);
                 let exited = Arc::clone(&self.exited);

--- a/src/input/ev.rs
+++ b/src/input/ev.rs
@@ -1,6 +1,6 @@
 use crate::input;
 
-use input::scan::SCAN;
+use input::scan::SCANNED;
 use log::{error, info, warn};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -49,7 +49,7 @@ impl EvDevContext {
 
     /// Non-blocking function that will open the provided path and wait for more data with epoll
     pub fn start(&mut self) {
-        let path = SCAN.get_path(self.device);
+        let path = SCANNED.get_path(self.device);
 
         self.started.store(true, Ordering::Relaxed);
         self.exited.store(false, Ordering::Relaxed);

--- a/src/input/ev.rs
+++ b/src/input/ev.rs
@@ -55,7 +55,7 @@ impl EvDevContext {
         self.exited.store(false, Ordering::Relaxed);
         self.exit_requested.store(false, Ordering::Relaxed);
 
-        match evdev::Device::open(path) {
+        match SCANNED.get_device(self.device) {
             Err(e) => error!("Error while reading events from epoll fd: {0}", e),
             Ok(mut dev) => {
                 let mut v = vec![epoll::Event {

--- a/src/input/gpio.rs
+++ b/src/input/gpio.rs
@@ -4,7 +4,7 @@ use evdev::raw::input_event;
 use log::error;
 use std::sync::atomic::{AtomicBool, Ordering};
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub enum PhysicalButton {
     LEFT,
     MIDDLE,
@@ -13,7 +13,7 @@ pub enum PhysicalButton {
     WAKEUP,
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub enum GPIOEvent {
     Press { button: PhysicalButton },
     Unpress { button: PhysicalButton },

--- a/src/input/gpio.rs
+++ b/src/input/gpio.rs
@@ -49,37 +49,31 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Option<InputE
             None
         }
         ecodes::EV_KEY => {
-            let (p, before_state) = match ev.code {
-                ecodes::KEY_HOME => (
-                    PhysicalButton::MIDDLE,
-                    state.states[0].fetch_and(ev.value != 0, Ordering::Relaxed),
-                ),
-                ecodes::KEY_LEFT => (
-                    PhysicalButton::LEFT,
-                    state.states[1].fetch_and(ev.value != 0, Ordering::Relaxed),
-                ),
-                ecodes::KEY_RIGHT => (
-                    PhysicalButton::RIGHT,
-                    state.states[2].fetch_and(ev.value != 0, Ordering::Relaxed),
-                ),
-                ecodes::KEY_POWER => (
-                    PhysicalButton::POWER,
-                    state.states[3].fetch_and(ev.value != 0, Ordering::Relaxed),
-                ),
-                ecodes::KEY_WAKEUP => (
-                    PhysicalButton::WAKEUP,
-                    state.states[4].fetch_and(ev.value != 0, Ordering::Relaxed),
-                ),
+            let p = match ev.code {
+                ecodes::KEY_HOME => {
+                    state.states[0].store(ev.value != 0, Ordering::Relaxed);
+                    PhysicalButton::MIDDLE
+                }
+                ecodes::KEY_LEFT => {
+                    state.states[1].store(ev.value != 0, Ordering::Relaxed);
+                    PhysicalButton::LEFT
+                }
+                ecodes::KEY_RIGHT => {
+                    state.states[2].store(ev.value != 0, Ordering::Relaxed);
+                    PhysicalButton::RIGHT
+                }
+                ecodes::KEY_POWER => {
+                    state.states[3].store(ev.value != 0, Ordering::Relaxed);
+                    PhysicalButton::POWER
+                }
+                ecodes::KEY_WAKEUP => {
+                    state.states[4].store(ev.value != 0, Ordering::Relaxed);
+                    PhysicalButton::WAKEUP
+                }
                 _ => return None,
             };
 
-            // Edge trigger -- debouncing
-            let new_state = ev.value != 0;
-            if new_state == before_state {
-                return None;
-            }
-
-            let event = if new_state {
+            let event = if ev.value != 0 {
                 GPIOEvent::Press { button: p }
             } else {
                 GPIOEvent::Unpress { button: p }

--- a/src/input/gpio.rs
+++ b/src/input/gpio.rs
@@ -44,11 +44,11 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Option<InputE
         _ => unreachable!(),
     };
     match ev._type {
-        0 => {
+        ecodes::EV_SYN => {
             /* safely ignored. sync event*/
             None
         }
-        1 => {
+        ecodes::EV_KEY => {
             let (p, before_state) = match ev.code {
                 ecodes::KEY_HOME => (
                     PhysicalButton::MIDDLE,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -14,7 +14,7 @@ pub mod multitouch;
 /// Contains the ev codes in use
 pub mod ecodes;
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Copy, Clone, Debug, Hash, Eq)]
 pub enum InputDevice {
     Wacom,
     Multitouch,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -14,6 +14,10 @@ pub mod multitouch;
 /// Contains the ev codes in use
 pub mod ecodes;
 
+/// Figures out where the input devices are as well as
+/// device dependant properties
+pub mod scan;
+
 #[derive(PartialEq, Copy, Clone, Debug, Hash, Eq)]
 pub enum InputDevice {
     Wacom,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -60,7 +60,7 @@ impl InputDeviceState {
     }
 }
 
-#[derive(PartialEq, Clone)]
+#[derive(PartialEq, Clone, Debug)]
 pub enum InputEvent {
     WacomEvent { event: wacom::WacomEvent },
     MultitouchEvent { event: multitouch::MultitouchEvent },

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -18,6 +18,9 @@ pub mod ecodes;
 /// device dependant properties
 pub mod scan;
 
+/// Utility for rotating
+pub mod rotate;
+
 #[derive(PartialEq, Copy, Clone, Debug, Hash, Eq)]
 pub enum InputDevice {
     Wacom,

--- a/src/input/multitouch.rs
+++ b/src/input/multitouch.rs
@@ -11,8 +11,10 @@ use std::sync::{
     Mutex,
 };
 
-const MT_HSCALAR: f32 = (DISPLAYWIDTH as f32) / (MTWIDTH as f32);
-const MT_VSCALAR: f32 = (DISPLAYHEIGHT as f32) / (MTHEIGHT as f32);
+lazy_static! {
+    static ref MT_HSCALAR: f32 = (DISPLAYWIDTH as f32) / (*MTWIDTH as f32);
+    static ref MT_VSCALAR: f32 = (DISPLAYHEIGHT as f32) / (*MTHEIGHT as f32);
+}
 
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub struct Finger {
@@ -129,13 +131,13 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Vec<InputEven
                     vec![]
                 }
                 ecodes::ABS_MT_POSITION_X => {
-                    let scaled_val = (f32::from(MTWIDTH - ev.value as u16) * MT_HSCALAR) as u16;
+                    let scaled_val = (f32::from(*MTWIDTH - ev.value as u16) * *MT_HSCALAR) as u16;
                     fingers.entry(current_slot).or_default().pos.x = scaled_val;
                     fingers.entry(current_slot).or_default().pos_updated = true;
                     vec![]
                 }
                 ecodes::ABS_MT_POSITION_Y => {
-                    let scaled_val = (f32::from(MTHEIGHT - ev.value as u16) * MT_VSCALAR) as u16;
+                    let scaled_val = (f32::from(*MTHEIGHT - ev.value as u16) * *MT_VSCALAR) as u16;
                     fingers.entry(current_slot).or_default().pos.y = scaled_val;
                     fingers.entry(current_slot).or_default().pos_updated = true;
                     vec![]

--- a/src/input/multitouch.rs
+++ b/src/input/multitouch.rs
@@ -1,11 +1,11 @@
+use super::ecodes;
 use crate::device::CURRENT_DEVICE;
 use crate::framebuffer::cgmath;
 use crate::framebuffer::common::{DISPLAYHEIGHT, DISPLAYWIDTH, MTHEIGHT, MTWIDTH};
 use crate::input::rotate::CoordinatePart;
 use crate::input::scan::SCANNED;
-
-use super::ecodes;
 use crate::input::{InputDeviceState, InputEvent};
+
 use evdev::raw::input_event;
 use fxhash::FxHashMap;
 use log::{debug, warn};

--- a/src/input/multitouch.rs
+++ b/src/input/multitouch.rs
@@ -77,10 +77,6 @@ impl MultitouchEvent {
     }
 }
 
-/// Take a rotated part and update the position of the finger while scaling
-/// it properly to the framebuffer size as well.
-fn update_finger_with_part(finger: &mut Finger, rotated_part: CoordinatePart) {}
-
 pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Vec<InputEvent> {
     let state = match outer_state {
         InputDeviceState::MultitouchState(ref state_arc) => state_arc,

--- a/src/input/multitouch.rs
+++ b/src/input/multitouch.rs
@@ -53,7 +53,7 @@ impl ::std::default::Default for MultitouchState {
     }
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub enum MultitouchEvent {
     Press { finger: Finger },
     Release { finger: Finger },

--- a/src/input/multitouch.rs
+++ b/src/input/multitouch.rs
@@ -2,7 +2,7 @@ use crate::device::CURRENT_DEVICE;
 use crate::framebuffer::cgmath;
 use crate::framebuffer::common::{DISPLAYHEIGHT, DISPLAYWIDTH, MTHEIGHT, MTWIDTH};
 use crate::input::rotate::CoordinatePart;
-use crate::input::scan::SCAN;
+use crate::input::scan::SCANNED;
 
 use super::ecodes;
 use crate::input::{InputDeviceState, InputEvent};
@@ -136,7 +136,7 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Vec<InputEven
                 ecodes::ABS_MT_POSITION_X => {
                     let rotated_part = CURRENT_DEVICE.get_multitouch_rotation().rotate_part(
                         CoordinatePart::X(ev.value as u16),
-                        &SCAN.multitouch_orig_size,
+                        &SCANNED.multitouch_orig_size,
                     );
                     let finger: &mut Finger = fingers.entry(current_slot).or_default();
                     match rotated_part {
@@ -153,7 +153,7 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Vec<InputEven
                 ecodes::ABS_MT_POSITION_Y => {
                     let rotated_part = CURRENT_DEVICE.get_multitouch_rotation().rotate_part(
                         CoordinatePart::Y(ev.value as u16),
-                        &SCAN.multitouch_orig_size,
+                        &SCANNED.multitouch_orig_size,
                     );
                     let finger: &mut Finger = fingers.entry(current_slot).or_default();
                     match rotated_part {

--- a/src/input/rotate.rs
+++ b/src/input/rotate.rs
@@ -1,0 +1,107 @@
+use cgmath::{Point2, Vector2};
+
+/// Describing the rotation of input devices.
+pub enum InputDeviceRotation {
+    /// When viewing the device in the standard portrait roation,
+    /// the origin of this input device is on the top left
+    Rot0,
+
+    /// When viewing the device in the standard portrait roation,
+    /// the origin of this input device is on the top right
+    Rot90,
+
+    /// When viewing the device in the standard portrait roation,
+    /// the origin of this input device is on the bottom right
+    Rot180,
+
+    /// When viewing the device in the standard portrait roation,
+    /// the origin of this input device is on the bottom left
+    Rot270,
+}
+
+pub enum CoordinatePart {
+    X(u16),
+    Y(u16),
+}
+
+impl InputDeviceRotation {
+    /// Takes a single coordinate part (`seg` == x or y coord) and returns the new coordinate
+    /// depending on the rotation of the device.
+    /// `size` must be the original size of the ev device that is used (the constants in framebuffer::common
+    /// are already rotated to fit the typical portrait view of the framebuffer!).
+    pub fn rotate_part(&self, seg: CoordinatePart, size: &Vector2<u16>) -> CoordinatePart {
+        match seg {
+            CoordinatePart::X(x) => match self {
+                InputDeviceRotation::Rot0 => CoordinatePart::X(x),
+                InputDeviceRotation::Rot90 => CoordinatePart::Y(x),
+                InputDeviceRotation::Rot180 => CoordinatePart::X(size.x - x),
+                InputDeviceRotation::Rot270 => CoordinatePart::Y(size.x - x),
+            },
+            CoordinatePart::Y(y) => match self {
+                InputDeviceRotation::Rot0 => CoordinatePart::Y(y),
+                InputDeviceRotation::Rot90 => CoordinatePart::X(size.y - y),
+                InputDeviceRotation::Rot180 => CoordinatePart::Y(size.y - y),
+                InputDeviceRotation::Rot270 => CoordinatePart::X(y),
+            },
+        }
+    }
+
+    /// Same as `rotate_part` but for a whole point.
+    pub fn rotate_point(&self, point: &Point2<u16>, size: &Vector2<u16>) -> Point2<u16> {
+        let rot_seg_x = self.rotate_part(CoordinatePart::X(point.x), size);
+        let rot_seg_y = self.rotate_part(CoordinatePart::Y(point.y), size);
+
+        if let CoordinatePart::X(x) = rot_seg_x {
+            if let CoordinatePart::Y(y) = rot_seg_y {
+                return Point2 { x, y };
+            }
+        }
+
+        if let CoordinatePart::X(x) = rot_seg_y {
+            if let CoordinatePart::Y(y) = rot_seg_x {
+                return Point2 { x, y };
+            }
+        }
+
+        unreachable!()
+    }
+
+    /// Whether based on the original rotation, width and height should be swapped.
+    pub fn should_swap_size_axes(&self) -> bool {
+        match self {
+            InputDeviceRotation::Rot0 | InputDeviceRotation::Rot180 => false,
+            InputDeviceRotation::Rot90 | InputDeviceRotation::Rot270 => true,
+        }
+    }
+
+    /// Returns the same dimensions.
+    /// These are swapped however when `should_swap_dimensions() == true`
+    pub fn rotated_size(&self, src_size: &Vector2<u16>) -> Vector2<u16> {
+        if self.should_swap_size_axes() {
+            Vector2 {
+                x: src_size.y,
+                y: src_size.x,
+            }
+        } else {
+            src_size.clone()
+        }
+    }
+}
+
+mod test {
+    use super::InputDeviceRotation::*;
+    use cgmath::{Point2, Vector2};
+
+    #[test]
+    fn check_rotations() {
+        let point = Point2 { x: 0, y: 0 };
+        let size = Vector2 { x: 200, y: 100 };
+        assert_eq!(Rot0.rotate_point(&point, &size), Point2 { x: 0, y: 0 });
+        assert_eq!(Rot90.rotate_point(&point, &size), Point2 { x: 100, y: 0 });
+        assert_eq!(
+            Rot180.rotate_point(&point, &size),
+            Point2 { x: 200, y: 100 }
+        );
+        assert_eq!(Rot270.rotate_point(&point, &size), Point2 { x: 0, y: 200 });
+    }
+}

--- a/src/input/rotate.rs
+++ b/src/input/rotate.rs
@@ -88,6 +88,7 @@ impl InputDeviceRotation {
     }
 }
 
+#[cfg(test)]
 mod test {
     use super::InputDeviceRotation::*;
     use cgmath::{Point2, Vector2};

--- a/src/input/rotate.rs
+++ b/src/input/rotate.rs
@@ -83,7 +83,7 @@ impl InputDeviceRotation {
                 y: src_size.x,
             }
         } else {
-            src_size.clone()
+            *src_size
         }
     }
 }

--- a/src/input/scan.rs
+++ b/src/input/scan.rs
@@ -205,7 +205,7 @@ impl EvDevs {
         if resuable_device.is_some() {
             let mut resuable_device = resuable_device.take().unwrap();
             resuable_device.events_no_sync()?; // Clear events until now
-            return Ok(resuable_device);
+            Ok(resuable_device)
         } else {
             evdev::Device::open(self.get_path(device))
         }

--- a/src/input/scan.rs
+++ b/src/input/scan.rs
@@ -35,7 +35,6 @@ impl EvDevsScan {
         let mut multitouch_path: Option<PathBuf> = None;
         let mut multitouch_dev: Option<evdev::Device> = None;
         let mut gpio_path: Option<PathBuf> = None;
-        let mut gpio_dev: Option<evdev::Device> = None;
 
         // Get all /dev/input/event* file paths
         let mut event_file_paths: Vec<PathBuf> = Vec::new();
@@ -72,7 +71,6 @@ impl EvDevsScan {
                 if dev.keys_supported().contains(evdev::KEY_POWER as usize) {
                     // The device for buttons has the KEY_POWER button and support KEY event types
                     gpio_path = Some(evdev_path.clone());
-                    gpio_dev = Some(dev);
                     continue;
                 }
             }
@@ -98,11 +96,10 @@ impl EvDevsScan {
         }
         let multitouch_path = multitouch_path.unwrap();
         let multitouch_dev = multitouch_dev.unwrap();
-        if gpio_path.is_none() || gpio_dev.is_none() {
+        if gpio_path.is_none() {
             panic!("Failed to find the gpio evdev!");
         }
         let gpio_path = gpio_path.unwrap();
-        let gpio_dev = gpio_dev.unwrap();
 
         // Figure out sizes
         let wacom_state = wacom_dev.state();

--- a/src/input/scan.rs
+++ b/src/input/scan.rs
@@ -1,0 +1,110 @@
+use super::InputDevice;
+use std::path::{Path, PathBuf};
+
+lazy_static! {
+    /// A singleton of the EvDevsScan object
+    pub static ref SCAN: EvDevsScan = EvDevsScan::new();
+}
+
+/// This struct contains the results of initially scaning all evdev devices,
+/// which allows for device model independancy.
+/// Some of its data is used by other constants.
+///
+/// EvDevsScan has some internal mutability to allow resuing the opened devices
+/// for some time to increase performance.
+/// TODO: Call this `EvDevsScanOutcome` or EvScanOutcome instead ??
+pub struct EvDevsScan {
+    wacom_path: PathBuf,
+    multitouch_path: PathBuf,
+    gpio_path: PathBuf,
+}
+
+impl EvDevsScan {
+    /// Scan all the evdev devices, figure out which is which
+    /// and get some additional data for lazy constants.
+    fn new() -> Self {
+        // All of these have to be found
+        let mut wacom_path: Option<PathBuf> = None;
+        let mut multitouch_path: Option<PathBuf> = None;
+        let mut gpio_path: Option<PathBuf> = None;
+
+        // Get all /dev/input/event* file paths
+        let mut event_file_paths: Vec<PathBuf> = Vec::new();
+        let input_dir = Path::new("/dev/input");
+        for entry in input_dir
+            .read_dir()
+            .unwrap_or_else(|_| panic!("Failed to list {:?}", input_dir))
+        {
+            let entry = entry.unwrap();
+            let file_name = entry.file_name().as_os_str().to_str().unwrap().to_owned();
+            if !file_name.starts_with("event") {
+                continue;
+            }
+
+            let evdev_path = input_dir.join(&file_name);
+            event_file_paths.push(evdev_path);
+        }
+
+        // Open and check capabilities of each event device
+        for evdev_path in event_file_paths {
+            let dev = evdev::Device::open(&evdev_path)
+                .unwrap_or_else(|_| panic!("Failed to scan {:?}", &evdev_path));
+            if dev.events_supported().contains(evdev::KEY) {
+                if dev.keys_supported().contains(evdev::BTN_STYLUS as usize)
+                    && dev.events_supported().contains(evdev::ABSOLUTE)
+                {
+                    // The device with the wacom digitizer has the BTN_STYLUS event
+                    // and support KEY as well as ABSOLUTE event types
+                    wacom_path = Some(evdev_path.clone());
+                }
+
+                if dev.keys_supported().contains(evdev::KEY_POWER as usize) {
+                    // The device for buttons has the KEY_POWER button and support KEY event types
+                    gpio_path = Some(evdev_path.clone());
+                }
+            }
+
+            if dev.events_supported().contains(evdev::RELATIVE)
+                && dev.absolute_axes_supported().contains(evdev::ABS_MT_SLOT)
+            {
+                // The touchscreen device has the ABS_MT_SLOT event and supports RELATIVE event types
+                multitouch_path = Some(evdev_path.clone());
+            }
+        }
+
+        // Ensure that all devices were found
+        if wacom_path.is_none() {
+            panic!("Failed to find the wacom digitizer evdev!");
+        }
+        let wacom_path = wacom_path.unwrap();
+        if multitouch_path.is_none() {
+            panic!("Failed to find the multitouch evdev!");
+        }
+        let multitouch_path = multitouch_path.unwrap();
+        if gpio_path.is_none() {
+            panic!("Failed to find the gpio evdev!");
+        }
+        let gpio_path = gpio_path.unwrap();
+
+        Self {
+            wacom_path,
+            multitouch_path,
+            gpio_path,
+        }
+    }
+
+    /// Get the path to a InputDevice
+    pub fn get_path(&self, device: InputDevice) -> &PathBuf {
+        match device {
+            InputDevice::Wacom => &self.wacom_path,
+            InputDevice::Multitouch => &self.multitouch_path,
+            InputDevice::GPIO => &self.gpio_path,
+            InputDevice::Unknown => panic!("\"InputDevice::Unkown\" is no device!"),
+        }
+    }
+
+    /// Get a ev device. If this is called early, it can get the device used for the initial scan.
+    pub fn get_device(&self, device: InputDevice) -> Result<evdev::Device, impl std::error::Error> {
+        evdev::Device::open(self.get_path(device))
+    }
+}

--- a/src/input/scan.rs
+++ b/src/input/scan.rs
@@ -10,7 +10,7 @@ pub const INITIAL_DEVS_AVAILABLE_FOR: Duration = Duration::from_millis(1000);
 
 lazy_static! {
     /// A singleton of the EvDevsScan object
-    pub static ref SCANNED: EvDevsScan = EvDevsScan::new();
+    pub static ref SCANNED: EvDevs = EvDevs::new();
 }
 
 /// This struct contains the results of initially scaning all evdev devices,
@@ -20,7 +20,7 @@ lazy_static! {
 /// EvDevsScan has some internal mutability to allow resuing the opened devices
 /// for some time to increase performance.
 /// TODO: Call this `EvDevsScanOutcome` or EvScanOutcome instead ??
-pub struct EvDevsScan {
+pub struct EvDevs {
     pub wacom_path: PathBuf,
     pub multitouch_path: PathBuf,
     pub gpio_path: PathBuf,
@@ -42,7 +42,7 @@ pub struct EvDevsScan {
     gpio_initial_dev: Arc<Mutex<Option<evdev::Device>>>,
 }
 
-impl EvDevsScan {
+impl EvDevs {
     /// Scan all the evdev devices, figure out which is which
     /// and get some additional data for lazy constants.
     fn new() -> Self {

--- a/src/input/scan.rs
+++ b/src/input/scan.rs
@@ -1,6 +1,11 @@
 use super::ecodes;
 use super::InputDevice;
+use log::debug;
 use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+pub const INITIAL_DEVS_AVAILABLE_FOR: Duration = Duration::from_millis(1000);
 
 lazy_static! {
     /// A singleton of the EvDevsScan object
@@ -18,6 +23,13 @@ pub struct EvDevsScan {
     pub wacom_path: PathBuf,
     pub multitouch_path: PathBuf,
     pub gpio_path: PathBuf,
+
+    // Those will be preserved in case they are needed fairly fast
+    // to prevent any additional delay of re-opening the fds.
+    // They will get removed fairly quickly though.
+    wacom_initial_dev: Arc<Mutex<Option<evdev::Device>>>,
+    multitouch_initial_dev: Arc<Mutex<Option<evdev::Device>>>,
+    gpio_initial_dev: Arc<Mutex<Option<evdev::Device>>>,
 
     pub wacom_width: u16,
     pub wacom_height: u16,
@@ -114,12 +126,32 @@ impl EvDevsScan {
         let mt_width = mt_state.abs_vals[ecodes::ABS_MT_POSITION_X as usize].maximum as u16;
         let mt_height = mt_state.abs_vals[ecodes::ABS_MT_POSITION_Y as usize].maximum as u16;
 
-        // Get values always from portrait view
+        let wacom_initial_dev = Arc::new(Mutex::new(Some(wacom_dev)));
+        let multitouch_initial_dev = Arc::new(Mutex::new(Some(multitouch_dev)));
+        let gpio_initial_dev = Arc::new(Mutex::new(Some(gpio_dev)));
+
+        // Spawn a thread to remove close the initial devices after some time
+        let wacom_initial_dev2 = wacom_initial_dev.clone();
+        let multitouch_initial_dev2 = multitouch_initial_dev.clone();
+        let gpio_initial_dev2 = gpio_initial_dev.clone();
+        std::thread::spawn(move || {
+            std::thread::sleep(INITIAL_DEVS_AVAILABLE_FOR);
+            // Remove devices (and thereby closing them)
+            (*(*wacom_initial_dev2).lock().unwrap()) = None;
+            (*(*multitouch_initial_dev2).lock().unwrap()) = None;
+            (*(*gpio_initial_dev2).lock().unwrap()) = None;
+            debug!("Closed initially opened evdev fds.");
+            //println!("Dropped devices");
+        });
 
         Self {
             wacom_path,
             multitouch_path,
             gpio_path,
+
+            wacom_initial_dev,
+            multitouch_initial_dev,
+            gpio_initial_dev,
 
             wacom_width,
             wacom_height,
@@ -141,6 +173,21 @@ impl EvDevsScan {
 
     /// Get a ev device. If this is called early, it can get the device used for the initial scan.
     pub fn get_device(&self, device: InputDevice) -> Result<evdev::Device, impl std::error::Error> {
-        evdev::Device::open(self.get_path(device))
+        let dev_arc = match device {
+            InputDevice::Wacom => self.wacom_initial_dev.clone(),
+            InputDevice::Multitouch => self.multitouch_initial_dev.clone(),
+            InputDevice::GPIO => self.gpio_initial_dev.clone(),
+            InputDevice::Unknown => panic!("\"InputDevice::Unkown\" is no device!"),
+        };
+
+        let mut resuable_device = dev_arc.lock().unwrap();
+        if resuable_device.is_some() {
+            let mut resuable_device = resuable_device.take().unwrap();
+            resuable_device.events_no_sync(); // Clear events until now
+                                              //println!("Reused device");
+            return Ok(resuable_device);
+        } else {
+            evdev::Device::open(self.get_path(device))
+        }
     }
 }

--- a/src/input/scan.rs
+++ b/src/input/scan.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 lazy_static! {
     /// A singleton of the EvDevsScan object
-    pub static ref SCAN: EvDevsScan = EvDevsScan::new();
+    pub static ref SCANNED: EvDevsScan = EvDevsScan::new();
 }
 
 /// This struct contains the results of initially scaning all evdev devices,

--- a/src/input/wacom.rs
+++ b/src/input/wacom.rs
@@ -1,7 +1,7 @@
 use super::ecodes;
 use crate::device::CURRENT_DEVICE;
 use crate::input::rotate::CoordinatePart;
-use crate::input::scan::SCAN;
+use crate::input::scan::SCANNED;
 use crate::input::{InputDeviceState, InputEvent};
 use atomic::Atomic;
 use evdev::raw::input_event;
@@ -173,7 +173,7 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Option<InputE
                 ecodes::ABS_X => {
                     let rotated_part = CURRENT_DEVICE
                         .get_wacom_rotation()
-                        .rotate_part(CoordinatePart::X(ev.value as u16), &SCAN.wacom_orig_size);
+                        .rotate_part(CoordinatePart::X(ev.value as u16), &SCANNED.wacom_orig_size);
                     match rotated_part {
                         CoordinatePart::X(rotated_value) => {
                             state.last_x.store(rotated_value, Ordering::Relaxed);
@@ -186,7 +186,7 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Option<InputE
                 ecodes::ABS_Y => {
                     let rotated_part = CURRENT_DEVICE
                         .get_wacom_rotation()
-                        .rotate_part(CoordinatePart::Y(ev.value as u16), &SCAN.wacom_orig_size);
+                        .rotate_part(CoordinatePart::Y(ev.value as u16), &SCANNED.wacom_orig_size);
                     match rotated_part {
                         CoordinatePart::X(rotated_value) => {
                             state.last_x.store(rotated_value, Ordering::Relaxed);

--- a/src/input/wacom.rs
+++ b/src/input/wacom.rs
@@ -8,8 +8,10 @@ use std::sync::atomic::{AtomicU16, Ordering};
 use crate::framebuffer::cgmath;
 use crate::framebuffer::common::{DISPLAYHEIGHT, DISPLAYWIDTH, WACOMHEIGHT, WACOMWIDTH};
 
-const WACOM_HSCALAR: f32 = (DISPLAYWIDTH as f32) / (WACOMWIDTH as f32);
-const WACOM_VSCALAR: f32 = (DISPLAYHEIGHT as f32) / (WACOMHEIGHT as f32);
+lazy_static! {
+    static ref WACOM_HSCALAR: f32 = (DISPLAYWIDTH as f32) / (*WACOMWIDTH as f32);
+    static ref WACOM_VSCALAR: f32 = (DISPLAYHEIGHT as f32) / (*WACOMHEIGHT as f32);
+}
 
 pub struct WacomState {
     last_x: AtomicU16,
@@ -88,8 +90,8 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Option<InputE
             Some(WacomPen::ToolPen) => Some(InputEvent::WacomEvent {
                 event: WacomEvent::Hover {
                     position: cgmath::Point2 {
-                        x: (f32::from(state.last_x.load(Ordering::Relaxed)) * WACOM_HSCALAR),
-                        y: (f32::from(state.last_y.load(Ordering::Relaxed)) * WACOM_VSCALAR),
+                        x: (f32::from(state.last_x.load(Ordering::Relaxed)) * *WACOM_HSCALAR),
+                        y: (f32::from(state.last_y.load(Ordering::Relaxed)) * *WACOM_VSCALAR),
                     },
                     distance: state.last_dist.load(Ordering::Relaxed) as u16,
                     tilt: cgmath::Vector2 {
@@ -101,8 +103,8 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Option<InputE
             Some(WacomPen::Touch) => Some(InputEvent::WacomEvent {
                 event: WacomEvent::Draw {
                     position: cgmath::Point2 {
-                        x: (f32::from(state.last_x.load(Ordering::Relaxed)) * WACOM_HSCALAR),
-                        y: (f32::from(state.last_y.load(Ordering::Relaxed)) * WACOM_VSCALAR),
+                        x: (f32::from(state.last_x.load(Ordering::Relaxed)) * *WACOM_HSCALAR),
+                        y: (f32::from(state.last_y.load(Ordering::Relaxed)) * *WACOM_VSCALAR),
                     },
                     pressure: state.last_pressure.load(Ordering::Relaxed),
                     tilt: cgmath::Vector2 {
@@ -168,7 +170,7 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Option<InputE
                 ecodes::ABS_X => {
                     // x and y are inverted due to remarkable
                     let val = ev.value as u16;
-                    state.last_y.store(WACOMHEIGHT - val, Ordering::Relaxed);
+                    state.last_y.store(*WACOMHEIGHT - val, Ordering::Relaxed);
                 }
                 ecodes::ABS_Y => {
                     state.last_x.store(ev.value as u16, Ordering::Relaxed);

--- a/src/input/wacom.rs
+++ b/src/input/wacom.rs
@@ -51,7 +51,7 @@ pub enum WacomPen {
     Stylus2 = ecodes::BTN_STYLUS2,
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub enum WacomEventType {
     InstrumentChange,
     Hover,
@@ -59,7 +59,7 @@ pub enum WacomEventType {
     Unknown,
 }
 
-#[derive(PartialEq, Copy, Clone)]
+#[derive(PartialEq, Copy, Clone, Debug)]
 pub enum WacomEvent {
     InstrumentChange {
         pen: WacomPen,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,9 @@ pub mod input;
 /// Simple battery and charging status provider
 pub mod battery;
 
+// TODO: Docs
+pub mod device;
+
 /// Contains the `ApplicationContext`, which is a general framework that can be used to either build
 /// your application or design your I/O code after. It uses rudimentary UI elements and adds them
 /// to a scene after wrapping them in `UIElementWrapper`. None of these are mandatory to be used.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,8 @@ macro_rules! end_bench {
 
 #[macro_use]
 extern crate ioctl_gen;
+#[macro_use]
+extern crate lazy_static;
 
 pub use cgmath;
 pub use epoll;


### PR DESCRIPTION
This PR makes the input system compatible with the rM2.

The the rM2 the event files have changed their order. There are different ways of getting the correct file. I used @raisjn's [aproach](https://gist.github.com/raisjn/01b16286dcc4461a6643f40f8f553966) by checking the capabilities of each device (see [this issue](https://github.com/Eeems/oxide/issues/48) for more).

This basicially opens every `/dev/input/event*` file once before the first device is accessed to build a HashMap correlating all `InputDevice`s event file paths.

This should also keep working when a rM3 gets released.

One downside I found with this though is, that the Multitouch device on the rM1 has some serious delay when opening it.

```
reMarkable: /home/root/ ./input # Modified to measure detection times
Duration "/dev/input/event2" opening fd: Ok(110.121µs)
Duration "/dev/input/event2" checking caps: Ok(20.957µs)
Duration "/dev/input/event2" closing fd: Ok(39.373µs)
Duration "/dev/input/event1" opening fd: Ok(35.439177ms)  # <-- Takes long!
Duration "/dev/input/event1" checking caps: Ok(11.541µs)
Duration "/dev/input/event1" closing fd: Ok(146.286µs)
Duration "/dev/input/event0" opening fd: Ok(234.241µs)
Duration "/dev/input/event0" checking caps: Ok(10.666µs)
Duration "/dev/input/event0" closing fd: Ok(46.206µs)
Duration total: Ok(44.654802ms) # The increased time probably due to checking the system time
"/dev/input/event2" is GPIO
"/dev/input/event1" is Multitouch
"/dev/input/event0" is Wacom
Waiting for input events...
^C
```

So this will basicially add a 30-40ms delay to anyone using ANY input device with this lib.  
One mitigation would be to keep the evdev open and either pass it onto a evcontext or drop it if a timeout runs out. This would increase the complexity of code however and I'm not sure how this should best be implemented.

I'm also not sure whether the current code should be refactored into a own struct some other cleaner approach.

@raisjn, could you test [this gzipped input example](https://github.com/canselcik/libremarkable/files/5471541/input-newdebug.gz) on the rM2 as well as I don't own one. That particular binary also includes the "benchmarking" I showed in the above example to maybe see some changes on the rM2.

**NOTE:** I'll keep this PR a draft for now since some of the values also seem to have changed and something else with the touchscreen. @raisjn will probably have specifics on this. I also would appreciate any input here as to how make this update proper.

**NOTE2:** I also notices that this PR also updates the input.rs from PR #47. So this should probably be resolved first as I'm not sure how to properly separate the PRs (I should've seen this coming :|).