### PR TITLE
Fix wrong MT input mapping for the rM 2

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -42,6 +42,19 @@ pub struct Device {
     pub model: Model,
 }
 
+/// The here specified roation and inversions should get the device into portrait
+/// rotation where the origin (0, 0) is at the top left.
+/// Scaling is not specified here, but Inputs will scale the axis to match the
+/// size of the framebuffer.
+pub struct InputDevicePlacement {
+    /// What rotation is needed to get it into portrait rotation
+    pub rotation: InputDeviceRotation,
+    /// Whether to the x axis any axis AFTER a rotation was applied
+    pub invert_x: bool,
+    /// Whether to the y axis any axis AFTER a rotation was applied
+    pub invert_y: bool,
+}
+
 impl Device {
     fn new() -> Self {
         let model = Model::current_model()
@@ -53,16 +66,28 @@ impl Device {
         Self { model }
     }
 
-    pub fn get_multitouch_rotation(&self) -> InputDeviceRotation {
+    pub fn get_multitouch_placement(&self) -> InputDevicePlacement {
         match self.model {
-            Model::Gen1 => InputDeviceRotation::Rot180,
-            Model::Gen2 => InputDeviceRotation::Rot270,
+            Model::Gen1 => InputDevicePlacement {
+                rotation: InputDeviceRotation::Rot180,
+                invert_x: false,
+                invert_y: false,
+            },
+            Model::Gen2 => InputDevicePlacement {
+                rotation: InputDeviceRotation::Rot180,
+                invert_x: true,
+                invert_y: false,
+            },
             Model::Unknown => unreachable!(),
         }
     }
 
-    pub fn get_wacom_rotation(&self) -> InputDeviceRotation {
-        // Not sure if the rotation of Gen2 differs
-        InputDeviceRotation::Rot270
+    pub fn get_wacom_placement(&self) -> InputDevicePlacement {
+        // The Wacom digitizer on Gen1 and Gen2 is placed the same
+        InputDevicePlacement {
+            rotation: InputDeviceRotation::Rot270,
+            invert_x: false,
+            invert_y: false,
+        }
     }
 }

--- a/src/input/multitouch.rs
+++ b/src/input/multitouch.rs
@@ -134,10 +134,21 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Vec<InputEven
                     vec![]
                 }
                 ecodes::ABS_MT_POSITION_X => {
-                    let rotated_part = CURRENT_DEVICE.get_multitouch_rotation().rotate_part(
+                    let placement = CURRENT_DEVICE.get_multitouch_placement();
+                    let mut rotated_part = placement.rotation.rotate_part(
                         CoordinatePart::X(ev.value as u16),
                         &SCANNED.multitouch_orig_size,
                     );
+                    if placement.invert_x {
+                        if let CoordinatePart::X(ref mut x_value) = rotated_part {
+                            *x_value = *MTWIDTH - *x_value;
+                        }
+                    }
+                    if placement.invert_y {
+                        if let CoordinatePart::Y(ref mut y_value) = rotated_part {
+                            *y_value = *MTHEIGHT - *y_value;
+                        }
+                    }
                     let finger: &mut Finger = fingers.entry(current_slot).or_default();
                     match rotated_part {
                         CoordinatePart::X(rotated_value) => {
@@ -151,10 +162,21 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Vec<InputEven
                     vec![]
                 }
                 ecodes::ABS_MT_POSITION_Y => {
-                    let rotated_part = CURRENT_DEVICE.get_multitouch_rotation().rotate_part(
+                    let placement = CURRENT_DEVICE.get_multitouch_placement();
+                    let mut rotated_part = placement.rotation.rotate_part(
                         CoordinatePart::Y(ev.value as u16),
                         &SCANNED.multitouch_orig_size,
                     );
+                    if placement.invert_x {
+                        if let CoordinatePart::X(ref mut x_value) = rotated_part {
+                            *x_value = *MTWIDTH - *x_value;
+                        }
+                    }
+                    if placement.invert_y {
+                        if let CoordinatePart::Y(ref mut y_value) = rotated_part {
+                            *y_value = *MTHEIGHT - *y_value;
+                        }
+                    }
                     let finger: &mut Finger = fingers.entry(current_slot).or_default();
                     match rotated_part {
                         CoordinatePart::X(rotated_value) => {

--- a/src/input/scan.rs
+++ b/src/input/scan.rs
@@ -129,7 +129,8 @@ impl EvDevs {
         };
         // X and Y are swapped for the wacom since rM1 and probably also rM2 have it rotated
         let (wacom_width, wacom_height) = crate::device::CURRENT_DEVICE
-            .get_wacom_rotation()
+            .get_wacom_placement()
+            .rotation
             .rotated_size(&wacom_orig_size)
             .into();
 
@@ -140,7 +141,8 @@ impl EvDevs {
         };
         // Axes are swapped on the rM2 (see InputDeviceRotation for more)
         let (mt_width, mt_height) = crate::device::CURRENT_DEVICE
-            .get_multitouch_rotation()
+            .get_multitouch_placement()
+            .rotation
             .rotated_size(&multitouch_orig_size)
             .into();
 

--- a/src/input/wacom.rs
+++ b/src/input/wacom.rs
@@ -171,9 +171,20 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Option<InputE
                         .store(ev.value as u16, Ordering::Relaxed);
                 }
                 ecodes::ABS_X => {
-                    let rotated_part = CURRENT_DEVICE
-                        .get_wacom_rotation()
+                    let placement = CURRENT_DEVICE.get_wacom_placement();
+                    let mut rotated_part = placement
+                        .rotation
                         .rotate_part(CoordinatePart::X(ev.value as u16), &SCANNED.wacom_orig_size);
+                    if placement.invert_x {
+                        if let CoordinatePart::X(ref mut x_value) = rotated_part {
+                            *x_value = *WACOMWIDTH - *x_value;
+                        }
+                    }
+                    if placement.invert_y {
+                        if let CoordinatePart::Y(ref mut y_value) = rotated_part {
+                            *y_value = *WACOMHEIGHT - *y_value;
+                        }
+                    }
                     match rotated_part {
                         CoordinatePart::X(rotated_value) => {
                             state.last_x.store(rotated_value, Ordering::Relaxed);
@@ -184,9 +195,20 @@ pub fn decode(ev: &input_event, outer_state: &InputDeviceState) -> Option<InputE
                     }
                 }
                 ecodes::ABS_Y => {
-                    let rotated_part = CURRENT_DEVICE
-                        .get_wacom_rotation()
+                    let placement = CURRENT_DEVICE.get_wacom_placement();
+                    let mut rotated_part = placement
+                        .rotation
                         .rotate_part(CoordinatePart::Y(ev.value as u16), &SCANNED.wacom_orig_size);
+                    if placement.invert_x {
+                        if let CoordinatePart::X(ref mut x_value) = rotated_part {
+                            *x_value = *WACOMWIDTH - *x_value;
+                        }
+                    }
+                    if placement.invert_y {
+                        if let CoordinatePart::Y(ref mut y_value) = rotated_part {
+                            *y_value = *WACOMHEIGHT - *y_value;
+                        }
+                    }
                     match rotated_part {
                         CoordinatePart::X(rotated_value) => {
                             state.last_x.store(rotated_value, Ordering::Relaxed);


### PR DESCRIPTION
Hi,
this PR finally adds the correct input mapping for Multitouch. Seems there was no way around adding inversion of axis. @raisjnn confirmed that this mapping (the input example) works on the rM2 now.

After this, the rM 2 should fully work when used together with [the shim](https://github.com/ddvk/remarkable2-framebuffer/).