### PR TITLE
Add support for the rM2 battery

### DIFF
--- a/src/battery.rs
+++ b/src/battery.rs
@@ -1,11 +1,19 @@
+use crate::device::CURRENT_DEVICE;
 use std::fs::File;
 use std::io::Read;
 
 // TODO: Implement API to allow callbacks backed via uevent / inotify
 
+// File tree containing the rM2 battery:
+// https://github.com/Eeems/oxide/issues/48#issue-698181952 (line 3166 of tree.txt)
+
 fn read_attribute(attr: &str) -> Result<String, String> {
     let mut data = String::new();
-    match File::open(format!("/sys/class/power_supply/bq27441-0/{0}", attr)) {
+    match File::open(format!(
+        "/sys/class/power_supply/{0}/{1}",
+        CURRENT_DEVICE.get_internal_battery_name(),
+        attr
+    )) {
         Err(e) => Err(format!("Unable to open file: {0}", e)),
         Ok(ref mut f) => match f.read_to_string(&mut data).unwrap_or(0) {
             0 => Err("Unable to read file".to_owned()),

--- a/src/device.rs
+++ b/src/device.rs
@@ -90,4 +90,13 @@ impl Device {
             invert_y: false,
         }
     }
+
+    /// Name of the battery as found in /sys/class/power_supply
+    pub fn get_internal_battery_name(&self) -> &str {
+        match self.model {
+            Model::Gen1 => "bq27441-0",
+            Model::Gen2 => "max77818_battery",
+            Model::Unknown => unreachable!(),
+        }
+    }
 }


### PR DESCRIPTION
Commit message: This was not tested. Though by viewing the file tree of /sys provided by @torwag [here](https://github.com/Eeems/oxide/issues/48#issue698181952) (file tree.txt line 3166) it seems that all methods are supported.

I didn't test whether this actually works on a rM 2 as I don't own that device. I'm confident though that it should work. I added the compiled demo binary that also reports that battery data. Please test whether it displays Charging/Discharging and the percentage on the reMarkable 2.

---

- [demo.tar.gz](https://github.com/canselcik/libremarkable/files/5740678/demo.tar.gz)
