### PR TITLE
fix: Skip groupadd if gid exists in Docker setup

### DIFF
--- a/docker-toolchain/Dockerfile
+++ b/docker-toolchain/Dockerfile
@@ -11,7 +11,7 @@ ARG ostype=Linux
 RUN apt-get -qq update
 RUN apt-get -qq install curl build-essential gcc-arm-linux-gnueabihf vim
 
-RUN bash -c 'if [ ${ostype} == Linux ]; then groupadd -r --gid ${GID} ${UNAME}; fi'
+RUN bash -c 'if [ ${ostype} == Linux ]; then groupadd -f -r --gid ${GID} ${UNAME}; fi'
 RUN useradd -u $UID -g $GID -m $UNAME
 USER $UNAME
 


### PR DESCRIPTION
Users who have a gid that matching an existing gid in the container will encounter an error when running `groupadd`. In order to allow the docker build process to continue, the addition of the `-f` flag will allow `groupadd` to exit successfully if the group already exists.