### PR TITLE
Only borrow the string we want to print

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -290,7 +290,7 @@ fn on_touch_rustlogo(app: &mut appctx::ApplicationContext<'_>, _element: UIEleme
             x: 1140.0,
             y: 240.0,
         },
-        format!("{0}", new_press_count),
+        &format!("{0}", new_press_count),
         65.0,
         color::BLACK,
         false,

--- a/src/appctx.rs
+++ b/src/appctx.rs
@@ -160,7 +160,7 @@ impl<'a> ApplicationContext<'a> {
         scale: f32,
         border_px: u32,
         border_padding: u32,
-        text: String,
+        text: &str,
         refresh: UIConstraintRefresh,
     ) -> mxcfb_rect {
         let framebuffer = self.get_framebuffer_ref();

--- a/src/framebuffer/draw.rs
+++ b/src/framebuffer/draw.rs
@@ -132,7 +132,7 @@ impl<'a> framebuffer::FramebufferDraw for core::Framebuffer<'a> {
     fn draw_text(
         &mut self,
         pos: Point2<f32>,
-        text: String,
+        text: &str,
         size: f32,
         col: color,
         dryrun: bool,
@@ -158,7 +158,7 @@ impl<'a> framebuffer::FramebufferDraw for core::Framebuffer<'a> {
         let c3 = f32::from(255 - components[2]);
 
         // Loop through the glyphs in the text, positing each one on a line
-        for glyph in dfont.layout(&text, scale, start) {
+        for glyph in dfont.layout(text, scale, start) {
             if let Some(bounding_box) = glyph.pixel_bounding_box() {
                 // Draw the glyph into the image per-pixel by using the draw closure
                 let bbmax_y = bounding_box.max.y as u32;

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -89,7 +89,7 @@ pub trait FramebufferDraw {
     fn draw_text(
         &mut self,
         pos: cgmath::Point2<f32>,
-        text: String,
+        text: &str,
         size: f32,
         col: common::color,
         dryrun: bool,

--- a/src/ui_extensions/element.rs
+++ b/src/ui_extensions/element.rs
@@ -159,7 +159,7 @@ impl UIElementWrapper {
                 scale,
                 border_px as u32,
                 8,
-                text.to_string(),
+                text,
                 refresh,
             ),
             UIElement::Image { ref img } => {

--- a/src/ui_extensions/luaext.rs
+++ b/src/ui_extensions/luaext.rs
@@ -98,7 +98,7 @@ pub fn lua_draw_text(
                 x: nx as f32,
                 y: ny as f32,
             },
-            stext,
+            &stext,
             nsize as f32,
             color::GRAY(ncolor as u8),
             false,


### PR DESCRIPTION
The text-drawing API takes ownership over the string where it doesn't need to, forcing some extra copies. Switching to `&str` should be more performant and about as ergonomic.