### PR TITLE
Support rM2 for musl builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ atomic = { version = "0.5.0" }
 cgmath = "0.17.0"
 fxhash = "0.2.1"
 once_cell = "1.7.2"
+libloading = "0.7.1"
 
 [features]
 enable-runtime-benchmarking = []

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -42,7 +42,7 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
                 let fd = open_func(
                     c_str.as_ptr() as *const libc::c_char,
                     libc::O_RDWR,
-                    0 as libc::mode_t,
+                    0_u32, /*as libc::mode_t*/
                 );
                 debug!("[rm2fb] open: using client, FD is {}", fd);
                 std::fs::File::from_raw_fd(fd)
@@ -77,6 +77,7 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
 
         let fix_screen_info = Framebuffer::get_fix_screeninfo(&device);
         let frame_length = (fix_screen_info.line_length * var_screen_info.yres) as usize;
+
         let mem_map = MmapOptions::new()
             .len(frame_length)
             .map_raw(&device)

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -192,6 +192,7 @@ pub trait FramebufferRefresh {
     fn wait_refresh_complete(&self, marker: u32) -> u32;
 }
 
+use super::framebuffer::common::NativeWidthType;
 use once_cell::sync::Lazy;
 
 type Rm2fbOpenFn = unsafe extern "C" fn(
@@ -202,12 +203,12 @@ type Rm2fbOpenFn = unsafe extern "C" fn(
 
 type Rm2fbIoctl2Fn = unsafe extern "C" fn(
     fd: libc::c_int,
-    request: libc::c_ulong,
+    request: NativeWidthType,
     ptr: *const libc::c_char,
 ) -> libc::c_int;
 
 type Rm2fbIoctl3Fn =
-    unsafe extern "C" fn(fd: libc::c_int, request: libc::c_ulong, ...) -> libc::c_int;
+    unsafe extern "C" fn(fd: libc::c_int, request: NativeWidthType, ...) -> libc::c_int;
 
 static LIBRM2FB_CLIENT: Lazy<Option<(Rm2fbOpenFn, Rm2fbIoctl2Fn, Rm2fbIoctl3Fn)>> =
     Lazy::new(|| unsafe {

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -195,7 +195,7 @@ pub trait FramebufferRefresh {
 use once_cell::sync::Lazy;
 static LIBRM2FB_CLIENT: Lazy<Option<libloading::Library>> = Lazy::new(|| unsafe {
     if let Ok(lib) = libloading::Library::new("/opt/lib/librm2fb_client.so.1") {
-        let init_func: libloading::Symbol<unsafe extern "C" fn()> = lib.get(b"_init").unwrap();
+        let init_func: libloading::Symbol<unsafe extern "C" fn()> = lib.get(b"init").unwrap();
         init_func();
         Some(lib)
     } else {

--- a/src/framebuffer/refresh.rs
+++ b/src/framebuffer/refresh.rs
@@ -1,7 +1,7 @@
 use std::os::unix::io::AsRawFd;
 use std::sync::atomic::Ordering;
 
-use log::warn;
+use log::{debug, warn};
 
 use super::LIBRM2FB_CLIENT;
 use crate::auto_ioctl;

--- a/src/framebuffer/refresh.rs
+++ b/src/framebuffer/refresh.rs
@@ -3,6 +3,8 @@ use std::sync::atomic::Ordering;
 
 use log::warn;
 
+use super::LIBRM2FB_CLIENT;
+use crate::auto_ioctl;
 use crate::framebuffer;
 use crate::framebuffer::common;
 use crate::framebuffer::core;
@@ -44,7 +46,7 @@ impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
 
         let pt: *const mxcfb_update_data = &whole;
         unsafe {
-            libc::ioctl(self.device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt);
+            auto_ioctl!(self.device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt);
         }
 
         if wait_completion {
@@ -53,10 +55,10 @@ impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
                 collision_test: 0,
             };
             unsafe {
-                if libc::ioctl(
+                if auto_ioctl!(
                     self.device.as_raw_fd(),
                     common::MXCFB_WAIT_FOR_UPDATE_COMPLETE,
-                    &mut markerdata,
+                    &mut markerdata
                 ) < 0
                 {
                     warn!("WAIT_FOR_UPDATE_COMPLETE failed after a full_refresh(..)");
@@ -128,7 +130,7 @@ impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
 
         let pt: *const mxcfb_update_data = &whole;
         unsafe {
-            libc::ioctl(self.device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt);
+            auto_ioctl!(self.device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt);
         }
 
         match mode {
@@ -138,10 +140,10 @@ impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
                     collision_test: 0,
                 };
                 unsafe {
-                    if libc::ioctl(
+                    if auto_ioctl!(
                         self.device.as_raw_fd(),
                         common::MXCFB_WAIT_FOR_UPDATE_COMPLETE,
-                        &mut markerdata,
+                        &mut markerdata
                     ) < 0
                     {
                         warn!("WAIT_FOR_UPDATE_COMPLETE failed after a partial_refresh(..)");
@@ -159,10 +161,10 @@ impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
             collision_test: 0,
         };
         unsafe {
-            if libc::ioctl(
+            if auto_ioctl!(
                 self.device.as_raw_fd(),
                 common::MXCFB_WAIT_FOR_UPDATE_COMPLETE,
-                &mut markerdata,
+                &mut markerdata
             ) < 0
             {
                 warn!("WAIT_FOR_UPDATE_COMPLETE failed");


### PR DESCRIPTION
Fixes https://github.com/canselcik/libremarkable/issues/65
Requires https://github.com/ddvk/remarkable2-framebuffer/pull/78

Loads librm2fb client lib on startup and uses it directly in lieu of going through libc (with LD_PRELOAD).
This is the only way to run binaries that use musl (instead of libc) on rM2.
Using musl isn't common in the homebrew rM apps community however. Non-musl binaries work fine with Toltec's tools on rM2. And rM1 has no issue as it doesn't have a fake framebuffer.

So far it seems on par with the LD_PRELOAD solution.
I haven't looked at precise measurements of speed nor CPU load. Running the demo seems to be as responsive when drawing with the pencil and multiple fingers. UI redraw is painfully slow (bottom buttons) and takes about 10s to complete, however that is the case with both solutions.

So I am suggesting to have this way of using rm2fb be enabled only for musl targets.
I haven't done that part yet though.