### PR TITLE
Add built-in swtfb client and enable musl builds on rM 2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
         args: --target ${{ env.TARGET }}
 
   test:
-    name: Test Suite on ${{ env.TARGET }}
+    name: Test Suite on gnueabihf
     runs-on: ubuntu-latest
     env:
       TARGET: armv7-unknown-linux-gnueabihf

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,11 @@ path = "examples/spy.rs"
 crate-type = ["dylib"]
 
 [[example]]
+name = "swtfb_sysv_spy"
+path = "examples/swtfb_sysv_spy.rs"
+crate-type = ["dylib"]
+
+[[example]]
 name = "demo"
 path = "examples/demo.rs"
 crate-type = ["bin"]

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ all: library examples
 
 .PHONY: examples
 examples:
-	cargo build --examples --release --target=$(TARGET)
+	cargo build --examples --release --target=armv7-unknown-linux-gnueabihf
 
 demo:
-	cargo build --example demo --release --target=$(TARGET)
+	cargo build --example demo --release --target=armv7-unknown-linux-gnueabihf
 
 x-demo:
 	cross build --example demo --release --target=$(TARGET)
@@ -22,7 +22,7 @@ deploy-x-demo: x-demo
 	ssh $(DEVICE_HOST) 'RUST_BACKTRACE=1 RUST_LOG=debug ./demo'
 
 bench:
-	cargo build --examples --release --target=$(TARGET) --features "enable-runtime-benchmarking"
+	cargo build --examples --release --target=armv7-unknown-linux-gnueabihf --features "enable-runtime-benchmarking"
 
 .PHONY: docker-env
 docker-env:
@@ -42,10 +42,10 @@ examples-docker: docker-env
 		-v cargo-registry:/home/builder/.cargo/registry \
 		-w /home/builder/libremarkable \
 		rust-build-remarkable:latest \
-		cargo build --examples --release --target=$(TARGET)
+		cargo build --examples --release --target=armv7-unknown-linux-gnueabihf
 
 library:
-	cargo build --release --target=$(TARGET)
+	cargo build --release --target=armv7-unknown-linux-gnueabihf
 
 test:
 	# Notice we aren't using the armv7 target here

--- a/examples/swtfb_sysv_spy.rs
+++ b/examples/swtfb_sysv_spy.rs
@@ -1,7 +1,7 @@
 use libc::{c_int, c_void, key_t, msqid_ds, size_t};
 use redhook::{hook, real};
 
-use libremarkable::framebuffer::swtfb_ipc;
+use libremarkable::framebuffer::swtfb_client;
 
 hook! {
   unsafe fn msgget(key: key_t, msgflg: c_int) -> c_int => msgget_spy {
@@ -23,26 +23,26 @@ hook! {
     unsafe fn msgsnd(msqid: c_int, msgp: *const c_void, msgsz: size_t, msgflg: c_int) -> c_int => msgsnd_spy {
         let res = real!(msgsnd)(msqid, msgp, msgsz, msgflg);
         eprintln!("Spy: msgsnd({:#x}, {:?}, {}, {:#x}) => {}", msqid, msgp, msgsz, msgflg, res);
-        if msgsz == std::mem::size_of::<swtfb_ipc::swtfb_update>() {
-            let msg = &*(msgp as *const swtfb_ipc::swtfb_update);
+        if msgsz == std::mem::size_of::<swtfb_client::swtfb_update>() {
+            let msg = &*(msgp as *const swtfb_client::swtfb_update);
                 eprintln!("Spy: msgsnd: Message: swt_update.mtype: {:?}, data: ... }}", msg.mtype);
                 let data_str_formatted = match msg.mtype {
-                    swtfb_ipc::MSG_TYPE::INIT_t => {
+                    swtfb_client::MSG_TYPE::INIT_t => {
                         format!("...")
                     },
-                    swtfb_ipc::MSG_TYPE::UPDATE_t => {
+                    swtfb_client::MSG_TYPE::UPDATE_t => {
                         format!("{:?}", msg.data.update)
                     },
-                    swtfb_ipc::MSG_TYPE::XO_t => {
+                    swtfb_client::MSG_TYPE::XO_t => {
                         format!("{:?}", msg.data.xochitl_update)
                     },
-                    swtfb_ipc::MSG_TYPE::WAIT_t => {
+                    swtfb_client::MSG_TYPE::WAIT_t => {
                         format!("{:?}", msg.data.wait_update)
                     }
                 };
                 eprintln!("Spy: msgsnd: Message: swt_update.data: {} }}", data_str_formatted);
         }else {
-            eprintln!("Spy: msgsnd: Error: Message is not sizeof(swtfb_update) (expected {}, got {})", std::mem::size_of::<swtfb_ipc::swtfb_update>(), msgsz)
+            eprintln!("Spy: msgsnd: Error: Message is not sizeof(swtfb_update) (expected {}, got {})", std::mem::size_of::<swtfb_client::swtfb_update>(), msgsz)
         }
         res
   }

--- a/examples/swtfb_sysv_spy.rs
+++ b/examples/swtfb_sysv_spy.rs
@@ -1,0 +1,49 @@
+use libc::{c_int, c_void, key_t, msqid_ds, size_t};
+use redhook::{hook, real};
+
+use libremarkable::framebuffer::swtfb_ipc;
+
+hook! {
+  unsafe fn msgget(key: key_t, msgflg: c_int) -> c_int => msgget_spy {
+        let res = real!(msgget)(key, msgflg);
+        eprintln!("Spy: msgget({:#x}, {:#x}) => {:#x}", key, msgflg, res);
+        res
+  }
+}
+
+hook! {
+      unsafe fn msgctl(msqid: c_int, cmd: c_int, buf: *mut msqid_ds) -> c_int => msgctl_spy {
+        let res = real!(msgctl)(msqid, cmd, buf);
+        eprintln!("Spy: msgctl({:#x}, {:#x}, {:?}) => {}", msqid, cmd, buf, res);
+        res
+  }
+}
+
+hook! {
+    unsafe fn msgsnd(msqid: c_int, msgp: *const c_void, msgsz: size_t, msgflg: c_int) -> c_int => msgsnd_spy {
+        let res = real!(msgsnd)(msqid, msgp, msgsz, msgflg);
+        eprintln!("Spy: msgsnd({:#x}, {:?}, {}, {:#x}) => {}", msqid, msgp, msgsz, msgflg, res);
+        if msgsz == std::mem::size_of::<swtfb_ipc::swtfb_update>() {
+            let msg = &*(msgp as *const swtfb_ipc::swtfb_update);
+                eprintln!("Spy: msgsnd: Message: swt_update.mtype: {:?}, data: ... }}", msg.mtype);
+                let data_str_formatted = match msg.mtype {
+                    swtfb_ipc::MSG_TYPE::INIT_t => {
+                        format!("...")
+                    },
+                    swtfb_ipc::MSG_TYPE::UPDATE_t => {
+                        format!("{:?}", msg.data.update)
+                    },
+                    swtfb_ipc::MSG_TYPE::XO_t => {
+                        format!("{:?}", msg.data.xochitl_update)
+                    },
+                    swtfb_ipc::MSG_TYPE::WAIT_t => {
+                        format!("{:?}", msg.data.wait_update)
+                    }
+                };
+                eprintln!("Spy: msgsnd: Message: swt_update.data: {} }}", data_str_formatted);
+        }else {
+            eprintln!("Spy: msgsnd: Error: Message is not sizeof(swtfb_update) (expected {}, got {})", std::mem::size_of::<swtfb_ipc::swtfb_update>(), msgsz)
+        }
+        res
+  }
+}

--- a/examples/swtfb_sysv_spy.rs
+++ b/examples/swtfb_sysv_spy.rs
@@ -40,7 +40,7 @@ hook! {
                         format!("{:?}", msg.data.wait_update)
                     }
                 };
-                eprintln!("Spy: msgsnd: Message: swt_update.data: {} }}", data_str_formatted);
+                eprintln!("Spy: msgsnd: Message: swt_update.data: {}", data_str_formatted);
         }else {
             eprintln!("Spy: msgsnd: Error: Message is not sizeof(swtfb_update) (expected {}, got {})", std::mem::size_of::<swtfb_client::swtfb_update>(), msgsz)
         }

--- a/src/appctx.rs
+++ b/src/appctx.rs
@@ -86,11 +86,9 @@ impl<'a> ApplicationContext<'a> {
         on_wacom: fn(&mut ApplicationContext<'_>, WacomEvent),
         on_touch: fn(&mut ApplicationContext<'_>, MultitouchEvent),
     ) -> ApplicationContext<'static> {
-        let fb_path = match crate::device::CURRENT_DEVICE.model {
-            crate::device::Model::Gen1 => "/dev/fb0",
-            crate::device::Model::Gen2 => "/dev/shm/swtfb.01",
-        };
-        let framebuffer = Box::new(core::Framebuffer::from_path(fb_path));
+        let framebuffer = Box::new(core::Framebuffer::from_path(
+            crate::device::CURRENT_DEVICE.get_framebuffer_path(),
+        ));
         let yres = framebuffer.var_screen_info.yres;
         let xres = framebuffer.var_screen_info.xres;
 

--- a/src/appctx.rs
+++ b/src/appctx.rs
@@ -86,7 +86,11 @@ impl<'a> ApplicationContext<'a> {
         on_wacom: fn(&mut ApplicationContext<'_>, WacomEvent),
         on_touch: fn(&mut ApplicationContext<'_>, MultitouchEvent),
     ) -> ApplicationContext<'static> {
-        let framebuffer = Box::new(core::Framebuffer::from_path("/dev/fb0"));
+        let fb_path = match crate::device::CURRENT_DEVICE.model {
+            crate::device::Model::Gen1 => "/dev/fb0",
+            crate::device::Model::Gen2 => "/dev/shm/swtfb.01",
+        };
+        let framebuffer = Box::new(core::Framebuffer::from_path(fb_path));
         let yres = framebuffer.var_screen_info.yres;
         let xres = framebuffer.var_screen_info.xres;
 

--- a/src/device.rs
+++ b/src/device.rs
@@ -118,4 +118,20 @@ impl Device {
             Model::Gen2 => "max77818_battery",
         }
     }
+
+    /// Path for gen 1 can be used as long as the rm2fb shim is active:
+    /// LD_PRELOAD="/opt/lib/librm2fb_client.so.1" <YOUR_BINARY> or
+    /// rm2fb-client YOUR_BINARY
+    /// https://github.com/ddvk/remarkable2-framebuffer/
+    /// If `/dev/shm/swtfb.01` is used for the framebuffer, the
+    /// internal swtfb_client will be used. This enables the use
+    /// of musl builds. But the rm2fb server must still be installed.
+    ///
+    /// TODO: Use proper path (needs breaking change for FramebufferBase::from_path() !)
+    pub fn get_framebuffer_path(&self) -> &'static str {
+        match self.model {
+            Model::Gen1 => "/dev/fb0",
+            Model::Gen2 => "/dev/shm/swtfb.01",
+        }
+    }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -31,6 +31,22 @@ impl Model {
             Err(ErrorKind::UnknownVersion(machine_name.to_owned()))
         }
     }
+
+    /// Path for gen 1 can be used as long as the rm2fb shim is active:
+    /// LD_PRELOAD="/opt/lib/librm2fb_client.so.1" <YOUR_BINARY> or
+    /// rm2fb-client YOUR_BINARY
+    /// https://github.com/ddvk/remarkable2-framebuffer/
+    /// If `/dev/shm/swtfb.01` is used for the framebuffer, the
+    /// internal swtfb_client will be used. This enables the use
+    /// of musl builds. But the rm2fb server must still be installed.
+    ///
+    /// TODO: Use proper path (needs breaking change for FramebufferBase::from_path() !)
+    pub fn framebuffer_path(&self) -> &'static str {
+        match self {
+            Model::Gen1 => "/dev/fb0",
+            Model::Gen2 => "/dev/shm/swtfb.01",
+        }
+    }
 }
 
 pub static CURRENT_DEVICE: Lazy<Device> = Lazy::new(Device::new);
@@ -119,19 +135,7 @@ impl Device {
         }
     }
 
-    /// Path for gen 1 can be used as long as the rm2fb shim is active:
-    /// LD_PRELOAD="/opt/lib/librm2fb_client.so.1" <YOUR_BINARY> or
-    /// rm2fb-client YOUR_BINARY
-    /// https://github.com/ddvk/remarkable2-framebuffer/
-    /// If `/dev/shm/swtfb.01` is used for the framebuffer, the
-    /// internal swtfb_client will be used. This enables the use
-    /// of musl builds. But the rm2fb server must still be installed.
-    ///
-    /// TODO: Use proper path (needs breaking change for FramebufferBase::from_path() !)
     pub fn get_framebuffer_path(&self) -> &'static str {
-        match self.model {
-            Model::Gen1 => "/dev/fb0",
-            Model::Gen2 => "/dev/shm/swtfb.01",
-        }
+        self.model.framebuffer_path()
     }
 }

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -46,14 +46,12 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
                 .expect("Failed to open swtfb shared buffer");
             (device, Some(mem_map))
         } else {
-            (
-                OpenOptions::new()
-                    .read(true)
-                    .write(true)
-                    .open(path_to_device)
-                    .unwrap(),
-                None,
-            )
+            let device = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .open(path_to_device)
+                .unwrap();
+            (device, None)
         };
 
         let mut var_screen_info = Framebuffer::get_var_screeninfo(&device, swtfb_client.as_ref());

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -12,7 +12,7 @@ use crate::framebuffer::common::{
     MXCFB_ENABLE_EPDC_ACCESS, MXCFB_SET_AUTO_UPDATE_MODE, MXCFB_SET_UPDATE_SCHEME,
 };
 use crate::framebuffer::screeninfo::{FixScreeninfo, VarScreeninfo};
-use crate::framebuffer::swtfb_ipc::SwtfbIpcQueue;
+use crate::framebuffer::swtfb_client::SwtfbClient;
 
 /// Framebuffer struct containing the state (latest update marker etc.)
 /// along with the var/fix screeninfo structs.
@@ -26,7 +26,7 @@ pub struct Framebuffer<'a> {
     /// like it has been done in `Framebuffer::new(..)`.
     pub var_screen_info: VarScreeninfo,
     pub fix_screen_info: FixScreeninfo,
-    pub swtfb_ipc_queue: Option<super::swtfb_ipc::SwtfbIpcQueue>,
+    pub swtfb_client: Option<super::swtfb_client::SwtfbClient>,
 }
 
 unsafe impl<'a> Send for Framebuffer<'a> {}
@@ -34,20 +34,29 @@ unsafe impl<'a> Sync for Framebuffer<'a> {}
 
 impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
     fn from_path(path_to_device: &str) -> Framebuffer<'_> {
-        let device = OpenOptions::new()
-            .read(true)
-            .write(true)
-            .open(path_to_device)
-            .unwrap();
-
-        let swtfb_ipc_queue = if path_to_device == "/dev/shm/swtfb.01" {
-            Some(SwtfbIpcQueue::new())
+        let swtfb_client = if path_to_device == "/dev/shm/swtfb.01" {
+            Some(SwtfbClient::new())
         } else {
             None
         };
 
-        let mut var_screen_info =
-            Framebuffer::get_var_screeninfo(&device, swtfb_ipc_queue.as_ref());
+        let (device, mem_map) = if let Some(ref swtfb_client) = swtfb_client {
+            let (device, mem_map) = swtfb_client
+                .open_buffer()
+                .expect("Failed to open swtfb shared buffer");
+            (device, Some(mem_map))
+        } else {
+            (
+                OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(path_to_device)
+                    .unwrap(),
+                None,
+            )
+        };
+
+        let mut var_screen_info = Framebuffer::get_var_screeninfo(&device, swtfb_client.as_ref());
         var_screen_info.xres = 1404;
         var_screen_info.yres = 1872;
         var_screen_info.rotate = 1;
@@ -64,15 +73,19 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
         var_screen_info.vmode = 0; // FB_VMODE_NONINTERLACED
         var_screen_info.accel_flags = 0;
 
-        Framebuffer::put_var_screeninfo(&device, swtfb_ipc_queue.as_ref(), &mut var_screen_info);
+        Framebuffer::put_var_screeninfo(&device, swtfb_client.as_ref(), &mut var_screen_info);
 
-        let fix_screen_info = Framebuffer::get_fix_screeninfo(&device, swtfb_ipc_queue.as_ref());
+        let fix_screen_info = Framebuffer::get_fix_screeninfo(&device, swtfb_client.as_ref());
         let frame_length = (fix_screen_info.line_length * var_screen_info.yres) as usize;
 
-        let mem_map = MmapOptions::new()
-            .len(frame_length)
-            .map_raw(&device)
-            .expect("Unable to map provided path");
+        let mem_map = if let Some(mem_map) = mem_map {
+            mem_map
+        } else {
+            MmapOptions::new()
+                .len(frame_length)
+                .map_raw(&device)
+                .expect("Unable to map provided path")
+        };
 
         // Load the font
         let font_data = include_bytes!("../../assets/Roboto-Regular.ttf");
@@ -84,29 +97,34 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
             default_font,
             var_screen_info,
             fix_screen_info,
-            swtfb_ipc_queue,
+            swtfb_client,
         }
     }
 
     fn set_epdc_access(&mut self, state: bool) {
-        println!("set_epdc_access");
-
-        if self.swtfb_ipc_queue.is_none() {
-            unsafe {
-                libc::ioctl(
-                    self.device.as_raw_fd(),
-                    if state {
-                        MXCFB_ENABLE_EPDC_ACCESS
-                    } else {
-                        MXCFB_DISABLE_EPDC_ACCESS
-                    },
-                );
-            };
+        if self.swtfb_client.is_some() {
+            // Not catched in rm2fb => noop
+            return;
         }
+
+        unsafe {
+            libc::ioctl(
+                self.device.as_raw_fd(),
+                if state {
+                    MXCFB_ENABLE_EPDC_ACCESS
+                } else {
+                    MXCFB_DISABLE_EPDC_ACCESS
+                },
+            );
+        };
     }
 
     fn set_autoupdate_mode(&mut self, mode: u32) {
-        println!("set_autoupdate_mode");
+        if self.swtfb_client.is_some() {
+            // https://github.com/ddvk/remarkable2-framebuffer/blob/1e288aa9/src/client/main.cpp#L137
+            // Is a noop in rm2fb
+            return;
+        }
 
         let m = mode.to_owned();
         unsafe {
@@ -119,7 +137,10 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
     }
 
     fn set_update_scheme(&mut self, scheme: u32) {
-        println!("set_update_scheme");
+        if self.swtfb_client.is_some() {
+            // Not catched in rm2fb => noop
+            return;
+        }
 
         let s = scheme.to_owned();
         unsafe {
@@ -131,57 +152,22 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
         };
     }
 
-    fn get_fix_screeninfo(device: &File, swtfb_ipc_queue: Option<&SwtfbIpcQueue>) -> FixScreeninfo {
-        println!("get_fix_screeninfo");
-
-        if swtfb_ipc_queue.is_some() {
-            // https://github.com/ddvk/remarkable2-framebuffer/blob/e594fc44/src/shared/ipc.cpp#L96
-            unsafe {
-                libc::ftruncate(
-                    device.as_raw_fd(),
-                    super::swtfb_ipc::BUF_SIZE as libc::off_t,
-                );
-            }
-            /*let mem_map = MmapOptions::new()
-            .len(super::swtfb_ipc::BUF_SIZE as usize)
-            .map_raw(device)
-            .expect("Unable to map provided path");*/
-            // https://github.com/ddvk/remarkable2-framebuffer/blob/1e288aa9/src/client/main.cpp#L217
-            let mut screeninfo: FixScreeninfo = unsafe { std::mem::zeroed() };
-            //screeninfo.smem_start = mem_map.as_ptr() as u32; // Not used anyway. TODO: Consider adding properly
-            screeninfo.smem_len = super::swtfb_ipc::BUF_SIZE as u32;
-            screeninfo.line_length =
-                super::swtfb_ipc::WIDTH as u32 * std::mem::size_of::<u16>() as u32;
-            return screeninfo;
+    fn get_fix_screeninfo(device: &File, swtfb_client: Option<&SwtfbClient>) -> FixScreeninfo {
+        if let Some(ref swtfb_client) = swtfb_client {
+            return swtfb_client.get_fix_screeninfo();
         }
+
         let mut info: FixScreeninfo = Default::default();
         let result = unsafe { ioctl(device.as_raw_fd(), FBIOGET_FSCREENINFO, &mut info) };
         assert!(result == 0, "FBIOGET_FSCREENINFO failed");
         info
     }
 
-    fn get_var_screeninfo(device: &File, swtfb_ipc_queue: Option<&SwtfbIpcQueue>) -> VarScreeninfo {
-        println!("get_var_screeninfo");
-
-        if swtfb_ipc_queue.is_some() {
-            // https://github.com/ddvk/remarkable2-framebuffer/blob/1e288aa9/src/client/main.cpp#L194
-            let mut screeninfo: VarScreeninfo = unsafe { std::mem::zeroed() };
-            screeninfo.xres = super::swtfb_ipc::WIDTH as u32;
-            screeninfo.yres = super::swtfb_ipc::HEIGHT as u32;
-            screeninfo.grayscale = 0;
-            screeninfo.bits_per_pixel = 8 * std::mem::size_of::<u16>() as u32;
-            screeninfo.xres_virtual = super::swtfb_ipc::WIDTH as u32;
-            screeninfo.yres_virtual = super::swtfb_ipc::HEIGHT as u32;
-
-            //set to RGB565
-            screeninfo.red.offset = 11;
-            screeninfo.red.length = 5;
-            screeninfo.green.offset = 5;
-            screeninfo.green.length = 6;
-            screeninfo.blue.offset = 0;
-            screeninfo.blue.length = 5;
-            return screeninfo;
+    fn get_var_screeninfo(device: &File, swtfb_client: Option<&SwtfbClient>) -> VarScreeninfo {
+        if let Some(ref swtfb_client) = swtfb_client {
+            return swtfb_client.get_var_screeninfo();
         }
+
         let mut info: VarScreeninfo = Default::default();
         let result = unsafe { ioctl(device.as_raw_fd(), FBIOGET_VSCREENINFO, &mut info) };
         assert!(result == 0, "FBIOGET_VSCREENINFO failed");
@@ -190,12 +176,10 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
 
     fn put_var_screeninfo(
         device: &std::fs::File,
-        swtfb_ipc_queue: Option<&SwtfbIpcQueue>,
+        swtfb_client: Option<&SwtfbClient>,
         var_screen_info: &mut VarScreeninfo,
     ) -> bool {
-        println!("put_var_screeninfo");
-
-        if swtfb_ipc_queue.is_some() {
+        if swtfb_client.is_some() {
             // https://github.com/ddvk/remarkable2-framebuffer/blob/1e288aa9/src/client/main.cpp#L214
             // Is a noop in rm2fb
             return true;
@@ -206,11 +190,9 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
     }
 
     fn update_var_screeninfo(&mut self) -> bool {
-        println!("update_var_screeninfo");
-
         Self::put_var_screeninfo(
             &self.device,
-            self.swtfb_ipc_queue.as_ref(),
+            self.swtfb_client.as_ref(),
             &mut self.var_screen_info,
         )
     }

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -35,7 +35,7 @@ unsafe impl<'a> Sync for Framebuffer<'a> {}
 impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
     fn from_path(path_to_device: &str) -> Framebuffer<'_> {
         let swtfb_client = if path_to_device == "/dev/shm/swtfb.01" {
-            Some(SwtfbClient::new())
+            Some(SwtfbClient::default())
         } else {
             None
         };
@@ -153,7 +153,7 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
     }
 
     fn get_fix_screeninfo(device: &File, swtfb_client: Option<&SwtfbClient>) -> FixScreeninfo {
-        if let Some(ref swtfb_client) = swtfb_client {
+        if let Some(swtfb_client) = swtfb_client {
             return swtfb_client.get_fix_screeninfo();
         }
 
@@ -164,7 +164,7 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
     }
 
     fn get_var_screeninfo(device: &File, swtfb_client: Option<&SwtfbClient>) -> VarScreeninfo {
-        if let Some(ref swtfb_client) = swtfb_client {
+        if let Some(swtfb_client) = swtfb_client {
             return swtfb_client.get_var_screeninfo();
         }
 

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -45,7 +45,6 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
         } else {
             None
         };
-        println!("Queue: {:?}", swtfb_ipc_queue.is_some());
 
         let mut var_screen_info =
             Framebuffer::get_var_screeninfo(&device, swtfb_ipc_queue.as_ref());
@@ -65,23 +64,15 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
         var_screen_info.vmode = 0; // FB_VMODE_NONINTERLACED
         var_screen_info.accel_flags = 0;
 
-        println!("FB from_path: 1");
-
         Framebuffer::put_var_screeninfo(&device, swtfb_ipc_queue.as_ref(), &mut var_screen_info);
-
-        println!("FB from_path: 2");
 
         let fix_screen_info = Framebuffer::get_fix_screeninfo(&device, swtfb_ipc_queue.as_ref());
         let frame_length = (fix_screen_info.line_length * var_screen_info.yres) as usize;
-
-        println!("FB from_path: 3");
 
         let mem_map = MmapOptions::new()
             .len(frame_length)
             .map_raw(&device)
             .expect("Unable to map provided path");
-
-        println!("FB from_path: 4");
 
         // Load the font
         let font_data = include_bytes!("../../assets/Roboto-Regular.ttf");

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -34,7 +34,7 @@ unsafe impl<'a> Sync for Framebuffer<'a> {}
 
 impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
     fn from_path(path_to_device: &str) -> Framebuffer<'_> {
-        let swtfb_client = if path_to_device == "/dev/shm/swtfb.01" {
+        let swtfb_client = if path_to_device == crate::device::Model::Gen2.framebuffer_path() {
             Some(SwtfbClient::default())
         } else {
             None

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -34,26 +34,16 @@ unsafe impl<'a> Sync for Framebuffer<'a> {}
 
 impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
     fn from_path(path_to_device: &str) -> Framebuffer<'_> {
-        let (swtfb_ipc_queue, device) = if path_to_device == "/dev/shm/swtfb.01" {
-            (
-                Some(SwtfbIpcQueue::new()),
-                OpenOptions::new()
-                    .read(true)
-                    .write(true)
-                    .truncate(true)
-                    .create(true)
-                    .open(path_to_device)
-                    .unwrap(),
-            )
+        let device = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(path_to_device)
+            .unwrap();
+
+        let swtfb_ipc_queue = if path_to_device == "/dev/shm/swtfb.01" {
+            Some(SwtfbIpcQueue::new())
         } else {
-            (
-                None,
-                OpenOptions::new()
-                    .read(true)
-                    .write(true)
-                    .open(path_to_device)
-                    .unwrap(),
-            )
+            None
         };
         println!("Queue: {:?}", swtfb_ipc_queue.is_some());
 
@@ -155,12 +145,12 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
 
         if swtfb_ipc_queue.is_some() {
             // https://github.com/ddvk/remarkable2-framebuffer/blob/e594fc44/src/shared/ipc.cpp#L96
-            /*unsafe {
+            unsafe {
                 libc::ftruncate(
                     device.as_raw_fd(),
                     super::swtfb_ipc::BUF_SIZE as libc::off_t,
                 );
-            }*/
+            }
             /*let mem_map = MmapOptions::new()
             .len(super::swtfb_ipc::BUF_SIZE as usize)
             .map_raw(device)

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -101,7 +101,7 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
 
     fn set_epdc_access(&mut self, state: bool) {
         if self.swtfb_client.is_some() {
-            // Not catched in rm2fb => noop
+            // Not caught/handled in rm2fb => noop
             return;
         }
 
@@ -136,7 +136,7 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
 
     fn set_update_scheme(&mut self, scheme: u32) {
         if self.swtfb_client.is_some() {
-            // Not catched in rm2fb => noop
+            // Not caught/handled in rm2fb => noop
             return;
         }
 

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -37,11 +37,7 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
         let device = OpenOptions::new()
             .read(true)
             .write(true)
-            .open(if path_to_device == "/dev/shm/swtfb.01" {
-                "/dev/fb0"
-            } else {
-                path_to_device
-            })
+            .open(path_to_device)
             .unwrap();
 
         let swtfb_ipc_queue = if path_to_device == "/dev/shm/swtfb.01" {

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -6,6 +6,8 @@ pub mod storage;
 
 pub mod io;
 
+pub mod swtfb_ipc;
+
 pub use cgmath;
 
 pub trait FramebufferIO {
@@ -119,14 +121,21 @@ pub trait FramebufferBase<'a> {
     /// Toggles update scheme
     fn set_update_scheme(&mut self, scheme: u32);
     /// Creates a FixScreeninfo struct and fills it using ioctl
-    fn get_fix_screeninfo(device: &std::fs::File) -> screeninfo::FixScreeninfo;
+    fn get_fix_screeninfo(
+        device: &std::fs::File,
+        swtfb_ipc_queue: Option<&swtfb_ipc::SwtfbIpcQueue>,
+    ) -> screeninfo::FixScreeninfo;
     /// Creates a VarScreeninfo struct and fills it using ioctl
-    fn get_var_screeninfo(device: &std::fs::File) -> screeninfo::VarScreeninfo;
+    fn get_var_screeninfo(
+        device: &std::fs::File,
+        swtfb_ipc_queue: Option<&swtfb_ipc::SwtfbIpcQueue>,
+    ) -> screeninfo::VarScreeninfo;
     /// Makes the proper ioctl call to set the VarScreenInfo.
     /// You must first update the contents of self.var_screen_info
     /// and then call this function.
     fn put_var_screeninfo(
         device: &std::fs::File,
+        swtfb_ipc_queue: Option<&swtfb_ipc::SwtfbIpcQueue>,
         var_screen_info: &mut screeninfo::VarScreeninfo,
     ) -> bool;
 

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -6,7 +6,7 @@ pub mod storage;
 
 pub mod io;
 
-pub mod swtfb_ipc;
+pub mod swtfb_client;
 
 pub use cgmath;
 
@@ -123,19 +123,19 @@ pub trait FramebufferBase<'a> {
     /// Creates a FixScreeninfo struct and fills it using ioctl
     fn get_fix_screeninfo(
         device: &std::fs::File,
-        swtfb_ipc_queue: Option<&swtfb_ipc::SwtfbIpcQueue>,
+        swtfb_client: Option<&swtfb_client::SwtfbClient>,
     ) -> screeninfo::FixScreeninfo;
     /// Creates a VarScreeninfo struct and fills it using ioctl
     fn get_var_screeninfo(
         device: &std::fs::File,
-        swtfb_ipc_queue: Option<&swtfb_ipc::SwtfbIpcQueue>,
+        swtfb_client: Option<&swtfb_client::SwtfbClient>,
     ) -> screeninfo::VarScreeninfo;
     /// Makes the proper ioctl call to set the VarScreenInfo.
     /// You must first update the contents of self.var_screen_info
     /// and then call this function.
     fn put_var_screeninfo(
         device: &std::fs::File,
-        swtfb_ipc_queue: Option<&swtfb_ipc::SwtfbIpcQueue>,
+        swtfb_client: Option<&swtfb_client::SwtfbClient>,
         var_screen_info: &mut screeninfo::VarScreeninfo,
     ) -> bool;
 

--- a/src/framebuffer/mxcfb.rs
+++ b/src/framebuffer/mxcfb.rs
@@ -33,7 +33,7 @@ impl ::std::default::Default for mxcfb_update_marker_data {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct mxcfb_alt_buffer_data {
     pub phys_addr: u32,
@@ -48,7 +48,7 @@ impl ::std::default::Default for mxcfb_alt_buffer_data {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 #[repr(C)]
 pub struct mxcfb_update_data {
     pub update_region: mxcfb_rect,

--- a/src/framebuffer/refresh.rs
+++ b/src/framebuffer/refresh.rs
@@ -42,34 +42,22 @@ impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
             ..Default::default()
         };
 
-        if let Some(ref queue) = self.swtfb_ipc_queue {
-            // TODO: Error checking
-            queue.send_mxcfb_update(&whole);
+        let update_succeeded = if let Some(ref swtfb_client) = self.swtfb_client {
+            swtfb_client.send_mxcfb_update(&whole)
         } else {
             let pt: *const mxcfb_update_data = &whole;
-            unsafe {
-                libc::ioctl(self.device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt);
-            }
+            (unsafe { libc::ioctl(self.device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt) }) > 0
+        };
+
+        if !update_succeeded {
+            warn!("Sending full_refresh update failed!")
         }
 
-        // TOOD: Check whether wait_complete now actually supported on rm2fb
-        if wait_completion && self.swtfb_ipc_queue.is_none() {
-            let mut markerdata = mxcfb_update_marker_data {
-                update_marker: whole.update_marker,
-                collision_test: 0,
-            };
-            unsafe {
-                if libc::ioctl(
-                    self.device.as_raw_fd(),
-                    common::MXCFB_WAIT_FOR_UPDATE_COMPLETE,
-                    &mut markerdata,
-                ) < 0
-                {
-                    warn!("WAIT_FOR_UPDATE_COMPLETE failed after a full_refresh(..)");
-                }
-            }
+        if wait_completion {
+            self.wait_refresh_complete(whole.update_marker)
+        } else {
+            whole.update_marker
         }
-        whole.update_marker
     }
 
     fn partial_refresh(
@@ -132,58 +120,45 @@ impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
             ..Default::default()
         };
 
-        if let Some(ref queue) = self.swtfb_ipc_queue {
-            // TODO: Error checking
-            queue.send_mxcfb_update(&whole);
+        let update_succeeded = if let Some(ref swtfb_client) = self.swtfb_client {
+            swtfb_client.send_mxcfb_update(&whole)
         } else {
             let pt: *const mxcfb_update_data = &whole;
-            unsafe {
-                libc::ioctl(self.device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt);
-            }
+            (unsafe { libc::ioctl(self.device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt) }) > 0
+        };
+
+        if !update_succeeded {
+            warn!("Sending full_refresh update failed!")
         }
 
         match mode {
             PartialRefreshMode::Wait | PartialRefreshMode::DryRun => {
-                let mut markerdata = mxcfb_update_marker_data {
-                    update_marker: whole.update_marker,
-                    collision_test: 0,
-                };
-                // TOOD: Check whether wait_complete now actually supported on rm2fb
-                if self.swtfb_ipc_queue.is_none() {
-                    unsafe {
-                        if libc::ioctl(
-                            self.device.as_raw_fd(),
-                            common::MXCFB_WAIT_FOR_UPDATE_COMPLETE,
-                            &mut markerdata,
-                        ) < 0
-                        {
-                            warn!("WAIT_FOR_UPDATE_COMPLETE failed after a partial_refresh(..)");
-                        }
-                    }
-                }
-                markerdata.collision_test
+                self.wait_refresh_complete(whole.update_marker)
             }
             PartialRefreshMode::Async => whole.update_marker,
         }
     }
 
     fn wait_refresh_complete(&self, marker: u32) -> u32 {
+        if let Some(ref swtfb_client) = self.swtfb_client {
+            swtfb_client.wait_for_update_complete();
+            // Assume success
+            return 0;
+        }
+
         let mut markerdata = mxcfb_update_marker_data {
             update_marker: marker,
             collision_test: 0,
         };
-        // TOOD: Check whether wait_complete now actually supported on rm2fb
-        if self.swtfb_ipc_queue.is_none() {
-            unsafe {
-                if libc::ioctl(
-                    self.device.as_raw_fd(),
-                    common::MXCFB_WAIT_FOR_UPDATE_COMPLETE,
-                    &mut markerdata,
-                ) < 0
-                {
-                    warn!("WAIT_FOR_UPDATE_COMPLETE failed");
-                }
-            };
+        unsafe {
+            if libc::ioctl(
+                self.device.as_raw_fd(),
+                common::MXCFB_WAIT_FOR_UPDATE_COMPLETE,
+                &mut markerdata,
+            ) < 0
+            {
+                warn!("WAIT_FOR_UPDATE_COMPLETE failed after a full_refresh(..)");
+            }
         }
         markerdata.collision_test
     }

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -6,6 +6,7 @@
 
 use super::mxcfb::mxcfb_update_data;
 use crate::framebuffer::screeninfo::{FixScreeninfo, VarScreeninfo};
+use log::warn;
 use memmap2::{MmapOptions, MmapRaw};
 use std::ffi::{c_void, CString};
 use std::fs::{File, OpenOptions};
@@ -218,7 +219,7 @@ impl SwtfbClient {
 impl Drop for SwtfbClient {
     fn drop(&mut self) {
         if unsafe { libc::msgctl(self.msqid, libc::IPC_RMID, ptr::null_mut()) } != 0 {
-            panic!("Got an error when closing ipc queue!")
+            warn!("Got an error when attempting to close an ipc queue!")
         }
     }
 }

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -16,8 +16,8 @@ use std::{env, mem, ptr};
 
 const SWTFB_MESSAGE_QUEUE_ID: i32 = 0x2257c;
 
-pub const WIDTH: i32 = crate::framebuffer::common::DISPLAYWIDTH;
-pub const HEIGHT: i32 = crate::framebuffer::common::DISPLAYHEIGHT;
+pub const WIDTH: i32 = crate::framebuffer::common::DISPLAYWIDTH as i32;
+pub const HEIGHT: i32 = crate::framebuffer::common::DISPLAYHEIGHT as i32;
 
 pub const BUF_SIZE: i32 = WIDTH * HEIGHT * std::mem::size_of::<u16>() as i32; // hardcoded size of display mem for rM2
 const SEM_WAIT_TIMEOUT_NS: i32 = 200_000_000;

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -20,7 +20,7 @@ pub const WIDTH: i32 = 1404;
 pub const HEIGHT: i32 = 1872;
 
 pub const BUF_SIZE: i32 = WIDTH * HEIGHT * std::mem::size_of::<u16>() as i32; // hardcoded size of display mem for rM2
-const SEM_WAIT_TIMEOUT: i32 = 200000000; /* 200 * 1000 * 1000, e.g. 200ms */
+const SEM_WAIT_TIMEOUT_NS: i32 = 200_000_000;
 
 /// long on 32 bit is 4 bytes as well!!
 #[derive(Debug, Clone, Copy)]

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -167,8 +167,8 @@ impl SwtfbClient {
         }
         timeout.tv_nsec += SEM_WAIT_TIMEOUT_NS;
         // Move overflow ns to secs
-        timeout.tv_sec += timeout.tv_nsec / 1e9;
-        timeout.tv_nsec %= 1e9;
+        timeout.tv_sec += timeout.tv_nsec / 1_000_000_000;
+        timeout.tv_nsec %= 1_000_000_000;
 
         unsafe {
             libc::sem_timedwait(sem, &timeout);

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -174,11 +174,10 @@ impl SwtfbClient {
             libc::clock_gettime(libc::CLOCK_REALTIME, &mut timeout);
         }
         timeout.tv_nsec += SEM_WAIT_TIMEOUT_NS;
+        // Move overflow ns to secs
+        timeout.tv_sec += timeout.tv_nsec / 1e9;
+        timeout.tv_nsec %= 1e9;
 
-        if timeout.tv_nsec >= 1_000_000_000 {
-            timeout.tv_nsec -= 1_000_000_000;
-            timeout.tv_sec += 1;
-        }
         unsafe {
             libc::sem_timedwait(sem, &timeout);
             libc::sem_unlink(sem_name_c.as_ptr() as *const libc::c_char);

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -11,7 +11,6 @@ use std::ffi::{c_void, CString};
 use std::fs::{File, OpenOptions};
 use std::io::Error as IoError;
 use std::os::unix::prelude::AsRawFd;
-use std::time::Instant;
 use std::{env, mem, ptr};
 
 const SWTFB_MESSAGE_QUEUE_ID: i32 = 0x2257c;
@@ -147,10 +146,8 @@ impl SwtfbClient {
             return;
         }
 
-        // UNTESTED!
         // https://github.com/ddvk/remarkable2-framebuffer/blob/1e288aa9/src/client/main.cpp#L149
 
-        let start = Instant::now();
         let sem_name_str = format!("/rm2fb.wait.{}", unsafe { libc::getpid() });
         let mut sem_name = [0u8; 512];
         for (i, byte) in sem_name_str.as_bytes().into_iter().enumerate() {
@@ -177,8 +174,6 @@ impl SwtfbClient {
             libc::sem_timedwait(sem, &timeout);
             libc::sem_unlink(sem_name_c.as_ptr() as *const u8);
         }
-
-        eprintln!("Waited {:?} for update to complete", start.elapsed());
     }
 
     pub fn send_wait_update(&self, wait_update: &wait_sem_data) -> bool {

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -109,7 +109,7 @@ impl SwtfbClient {
         let device = OpenOptions::new()
             .read(true)
             .write(true)
-            .open("/dev/shm/swtfb.01")?;
+            .open(crate::device::Model::Gen2.framebuffer_path())?;
         let ret = unsafe { libc::ftruncate(device.as_raw_fd(), BUF_SIZE as libc::off_t) };
         if ret < 0 {
             return Err(IoError::last_os_error());

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -166,7 +166,7 @@ impl SwtfbClient {
         unsafe {
             libc::clock_gettime(libc::CLOCK_REALTIME, &mut timeout);
         }
-        timeout.tv_nsec += SEM_WAIT_TIMEOUT;
+        timeout.tv_nsec += SEM_WAIT_TIMEOUT_NS;
 
         if timeout.tv_nsec >= 1_000_000_000 {
             timeout.tv_nsec -= 1_000_000_000;

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -19,11 +19,7 @@ const SWTFB_MESSAGE_QUEUE_ID: i32 = 0x2257c;
 pub const WIDTH: i32 = 1404;
 pub const HEIGHT: i32 = 1872;
 
-#[allow(non_upper_case_globals)]
-pub const maxWidth: i32 = 1404;
-#[allow(non_upper_case_globals)]
-pub const maxHeight: i32 = 1872;
-pub const BUF_SIZE: i32 = maxWidth * maxHeight * std::mem::size_of::<u16>() as i32; // hardcoded size of display mem for rM2
+pub const BUF_SIZE: i32 = WIDTH * HEIGHT * std::mem::size_of::<u16>() as i32; // hardcoded size of display mem for rM2
 const SEM_WAIT_TIMEOUT: i32 = 200000000; /* 200 * 1000 * 1000, e.g. 200ms */
 
 /// long on 32 bit is 4 bytes as well!!

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -163,7 +163,8 @@ impl SwtfbClient {
         }
         self.send_wait_update(&wait_sem_data { sem_name });
         let sem_name_c = CString::new(sem_name_str.as_str()).unwrap();
-        let sem = unsafe { libc::sem_open(sem_name_c.as_ptr() as *const libc::c_char, libc::O_CREAT) };
+        let sem =
+            unsafe { libc::sem_open(sem_name_c.as_ptr() as *const libc::c_char, libc::O_CREAT) };
 
         let mut timeout = libc::timespec {
             tv_nsec: 0,

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -132,7 +132,9 @@ impl SwtfbClient {
         })
     }
 
-    pub fn send_xochitl_update(&self, data: &xochitl_data) -> bool {
+    /// This function seems to be meant for internal use only.
+    #[allow(dead_code)]
+    fn send_xochitl_update(&self, data: &xochitl_data) -> bool {
         self.send(&swtfb_update {
             mtype: MSG_TYPE::XO_t,
             data: swtfb_update_data {

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -16,8 +16,8 @@ use std::{env, mem, ptr};
 
 const SWTFB_MESSAGE_QUEUE_ID: i32 = 0x2257c;
 
-pub const WIDTH: i32 = 1404;
-pub const HEIGHT: i32 = 1872;
+pub const WIDTH: i32 = crate::framebuffer::common::DISPLAYWIDTH;
+pub const HEIGHT: i32 = crate::framebuffer::common::DISPLAYHEIGHT;
 
 pub const BUF_SIZE: i32 = WIDTH * HEIGHT * std::mem::size_of::<u16>() as i32; // hardcoded size of display mem for rM2
 const SEM_WAIT_TIMEOUT_NS: i32 = 200_000_000;

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -95,14 +95,6 @@ impl Default for SwtfbClient {
         };
         assert!(msqid >= 0);
 
-        // Does nested need special handling?
-        // This may not be needed at all.
-        if env::var("RM2FB_ACTIVE").is_ok() {
-            env::set_var("RM2FB_NESTED", "1");
-        } else {
-            env::set_var("RM2FB_ACTIVE", "1");
-        }
-
         Self {
             msqid,
             do_wait_ioctl: env::var("RM2FB_NO_WAIT_IOCTL").is_err(),

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -91,7 +91,8 @@ impl SwtfbClient {
             panic!("Got an error when initializing/creating ipc queue!");
         }
 
-        // TODO: Nested not yet handled!
+        // Does nested need special handling?
+        // This may not be needed at all.
         if env::var("RM2FB_ACTIVE").is_ok() {
             env::set_var("RM2FB_NESTED", "1");
         } else {

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -5,6 +5,7 @@
 //! https://github.com/ddvk/remarkable2-framebuffer/issues/11
 
 use super::mxcfb::mxcfb_update_data;
+use crate::device;
 use crate::framebuffer::screeninfo::{FixScreeninfo, VarScreeninfo};
 use log::warn;
 use memmap2::{MmapOptions, MmapRaw};
@@ -81,6 +82,11 @@ pub struct SwtfbClient {
 
 impl Default for SwtfbClient {
     fn default() -> Self {
+        assert!(
+            device::CURRENT_DEVICE.model == device::Model::Gen2,
+            "SWTFB is not supported on devices other than rM 2"
+        );
+
         let msqid = unsafe {
             libc::msgget(
                 SWTFB_MESSAGE_QUEUE_ID,

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -35,6 +35,7 @@ pub enum MSG_TYPE {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[repr(C)]
 #[allow(non_camel_case_types, dead_code)]
 pub struct xochitl_data {
     pub x1: i32,
@@ -47,6 +48,7 @@ pub struct xochitl_data {
 }
 
 #[derive(Debug, Clone, Copy)]
+#[repr(C)]
 #[allow(non_camel_case_types, dead_code)]
 pub struct wait_sem_data {
     /// C string
@@ -55,6 +57,7 @@ pub struct wait_sem_data {
 
 /// MSG_TYPE has to match swtfb_update_data !!!
 #[derive(Clone, Copy)]
+#[repr(C)]
 #[allow(non_camel_case_types, dead_code)]
 pub struct swtfb_update {
     pub mtype: MSG_TYPE,
@@ -63,6 +66,7 @@ pub struct swtfb_update {
 }
 
 #[derive(Clone, Copy)]
+#[repr(C)]
 #[allow(non_camel_case_types, dead_code)]
 pub union swtfb_update_data {
     pub xochitl_update: xochitl_data,

--- a/src/framebuffer/swtfb_ipc.rs
+++ b/src/framebuffer/swtfb_ipc.rs
@@ -17,8 +17,9 @@ pub const maxWidth: i32 = 1404;
 pub const maxHeight: i32 = 1872;
 pub const BUF_SIZE: i32 = maxWidth * maxHeight * std::mem::size_of::<u16>() as i32; // hardcoded size of display mem for rM2
 
+/// long on 32 bit is 4 bytes as well!!
 #[derive(Debug, Clone, Copy)]
-#[repr(i64)]
+#[repr(i32)]
 #[allow(non_camel_case_types)]
 #[allow(dead_code)]
 pub enum MSG_TYPE {
@@ -53,6 +54,7 @@ pub struct wait_sem_data {
 pub struct swtfb_update {
     mtype: MSG_TYPE,
     data: swtfb_update_data,
+    //ms: u64,
 }
 
 #[derive(Clone, Copy)]

--- a/src/framebuffer/swtfb_ipc.rs
+++ b/src/framebuffer/swtfb_ipc.rs
@@ -103,7 +103,7 @@ impl SwtfbIpcQueue {
 
     pub fn send(&self, update: &swtfb_update) -> bool {
         unsafe {
-            let ptr = std::ptr::addr_of!(update) as *const std::ffi::c_void;
+            let ptr = std::ptr::addr_of!(*update) as *const std::ffi::c_void;
             println!("Ptr: {:?}", ptr);
             println!("Size: {}", std::mem::size_of::<swtfb_update>());
             libc::msgsnd(self.msqid, ptr, std::mem::size_of::<swtfb_update>(), 0) == 0

--- a/src/framebuffer/swtfb_ipc.rs
+++ b/src/framebuffer/swtfb_ipc.rs
@@ -34,42 +34,42 @@ pub enum MSG_TYPE {
 #[derive(Debug, Clone, Copy)]
 #[allow(non_camel_case_types, dead_code)]
 pub struct xochitl_data {
-    x1: i32,
-    y1: i32,
-    x2: i32,
-    y2: i32,
+    pub x1: i32,
+    pub y1: i32,
+    pub x2: i32,
+    pub y2: i32,
 
-    waveform: i32,
-    flags: i32,
+    pub waveform: i32,
+    pub flags: i32,
 }
 
 #[derive(Debug, Clone, Copy)]
 #[allow(non_camel_case_types, dead_code)]
 pub struct wait_sem_data {
     /// C string
-    sem_name: [u8; 512],
+    pub sem_name: [u8; 512],
 }
 
 /// MSG_TYPE has to match swtfb_update_data !!!
 #[derive(Clone, Copy)]
 #[allow(non_camel_case_types, dead_code)]
 pub struct swtfb_update {
-    mtype: MSG_TYPE,
-    data: swtfb_update_data,
+    pub mtype: MSG_TYPE,
+    pub data: swtfb_update_data,
     //ms: u64,
 }
 
 #[derive(Clone, Copy)]
 #[allow(non_camel_case_types, dead_code)]
 pub union swtfb_update_data {
-    xochitl_update: xochitl_data,
-    update: mxcfb_update_data,
-    wait_update: wait_sem_data,
+    pub xochitl_update: xochitl_data,
+    pub update: mxcfb_update_data,
+    pub wait_update: wait_sem_data,
 }
 
 pub struct SwtfbIpcQueue {
-    msqid: i32,
-    do_wait_ioctl: bool,
+    pub msqid: i32,
+    pub do_wait_ioctl: bool,
 }
 
 impl SwtfbIpcQueue {

--- a/src/framebuffer/swtfb_ipc.rs
+++ b/src/framebuffer/swtfb_ipc.rs
@@ -1,0 +1,129 @@
+//! This implements the IPC part of a rM2Framebuffer client to interact with this server:
+//! https://github.com/ddvk/remarkable2-framebuffer
+//!
+//! The client is developed according to the spec here:
+//! https://github.com/ddvk/remarkable2-framebuffer/issues/11
+
+const SWTFB_MESSAGE_QUEUE_ID: i32 = 0x2257c;
+
+use super::mxcfb::mxcfb_update_data;
+
+pub const WIDTH: i32 = 1404;
+pub const HEIGHT: i32 = 1872;
+
+#[allow(non_upper_case_globals)]
+pub const maxWidth: i32 = 1404;
+#[allow(non_upper_case_globals)]
+pub const maxHeight: i32 = 1872;
+pub const BUF_SIZE: i32 = maxWidth * maxHeight * std::mem::size_of::<u16>() as i32; // hardcoded size of display mem for rM2
+
+#[derive(Debug, Clone, Copy)]
+#[repr(i64)]
+#[allow(non_camel_case_types)]
+#[allow(dead_code)]
+pub enum MSG_TYPE {
+    INIT_t = 1,
+    UPDATE_t = 2,
+    XO_t = 3,
+    WAIT_t = 4,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[allow(non_camel_case_types, dead_code)]
+pub struct xochitl_data {
+    x1: i32,
+    y1: i32,
+    x2: i32,
+    y2: i32,
+
+    waveform: i32,
+    flags: i32,
+}
+
+#[derive(Debug, Clone, Copy)]
+#[allow(non_camel_case_types, dead_code)]
+pub struct wait_sem_data {
+    /// C string
+    sem_name: [u8; 512],
+}
+
+/// MSG_TYPE has to match swtfb_update_data !!!
+#[derive(Clone, Copy)]
+#[allow(non_camel_case_types, dead_code)]
+pub struct swtfb_update {
+    mtype: MSG_TYPE,
+    data: swtfb_update_data,
+}
+
+#[derive(Clone, Copy)]
+#[allow(non_camel_case_types, dead_code)]
+pub union swtfb_update_data {
+    xochitl_update: xochitl_data,
+    update: mxcfb_update_data,
+    wait_update: wait_sem_data,
+}
+
+pub struct SwtfbIpcQueue {
+    msqid: i32,
+}
+
+impl SwtfbIpcQueue {
+    pub fn new() -> Self {
+        let msqid = unsafe {
+            libc::msgget(
+                SWTFB_MESSAGE_QUEUE_ID,
+                libc::IPC_CREAT | libc::SHM_R | libc::SHM_W,
+            )
+        };
+        if msqid < 0 {
+            // TODO: Make proper error
+            panic!("Got an error when initializing/creating ipc queue!");
+        }
+        Self { msqid }
+    }
+
+    pub fn send(&self, update: &swtfb_update) -> bool {
+        unsafe {
+            let ptr = std::ptr::addr_of!(update) as *const std::ffi::c_void;
+            println!("Ptr: {:?}", ptr);
+            println!("Size: {}", std::mem::size_of::<swtfb_update>());
+            libc::msgsnd(self.msqid, ptr, std::mem::size_of::<swtfb_update>(), 0) == 0
+        }
+    }
+
+    pub fn send_mxcfb_update(&self, update: &mxcfb_update_data) -> bool {
+        println!("Sending update...");
+        let ret = self.send(&swtfb_update {
+            mtype: MSG_TYPE::UPDATE_t,
+            data: swtfb_update_data { update: *update },
+        });
+        println!("Update sent: {}", ret);
+        ret
+    }
+
+    pub fn send_xochitl_update(&self, data: &xochitl_data) -> bool {
+        self.send(&swtfb_update {
+            mtype: MSG_TYPE::XO_t,
+            data: swtfb_update_data {
+                xochitl_update: *data,
+            },
+        })
+    }
+
+    pub fn send_wait_update(&self, wait_update: &wait_sem_data) -> bool {
+        self.send(&swtfb_update {
+            mtype: MSG_TYPE::WAIT_t,
+            data: swtfb_update_data {
+                wait_update: *wait_update,
+            },
+        })
+    }
+}
+
+impl Drop for SwtfbIpcQueue {
+    fn drop(&mut self) {
+        if unsafe { libc::msgctl(self.msqid, libc::IPC_RMID, std::ptr::null_mut()) } != 0 {
+            panic!("Got an error when closing ipc queue!")
+        }
+    }
+}

--- a/src/framebuffer/swtfb_ipc.rs
+++ b/src/framebuffer/swtfb_ipc.rs
@@ -8,7 +8,6 @@ const SWTFB_MESSAGE_QUEUE_ID: i32 = 0x2257c;
 
 use super::mxcfb::mxcfb_update_data;
 use std::ffi::CString;
-use std::os::raw::c_char;
 
 pub const WIDTH: i32 = 1404;
 pub const HEIGHT: i32 = 1872;

--- a/src/framebuffer/swtfb_ipc.rs
+++ b/src/framebuffer/swtfb_ipc.rs
@@ -104,19 +104,15 @@ impl SwtfbIpcQueue {
     pub fn send(&self, update: &swtfb_update) -> bool {
         unsafe {
             let ptr = std::ptr::addr_of!(*update) as *const std::ffi::c_void;
-            println!("Ptr: {:?}", ptr);
-            println!("Size: {}", std::mem::size_of::<swtfb_update>());
             libc::msgsnd(self.msqid, ptr, std::mem::size_of::<swtfb_update>(), 0) == 0
         }
     }
 
     pub fn send_mxcfb_update(&self, update: &mxcfb_update_data) -> bool {
-        println!("Sending update...");
         let ret = self.send(&swtfb_update {
             mtype: MSG_TYPE::UPDATE_t,
             data: swtfb_update_data { update: *update },
         });
-        println!("Update sent: {}", ret);
         ret
     }
 


### PR DESCRIPTION
See #76 . This should also enable musl builds and hence solve that problem.

Code should be semi clean. As mentioned in #76 we might want to change "Core" and "Swtfb" into seperate backends (also todo when doing breaking changes: use `AsRef<std::path::Path>` in `from_path`).

Testing if wanted:
 - Musleabihf build should work for demo example
 - Demo example with libc should run with AND without shim (e.g. LD_PRELOAD=... or rm2fb-shim).

Artifacts built with `cross build --target=armv7-unknown-linux-gnueabihf --release --example demo` and `cross build --target=armv7-unknown-linux-musleabihf --release --example demo` : [demos.tar.gz](https://github.com/canselcik/libremarkable/files/7532384/demos.tar.gz)

New:
 - `framebuffer::swtfb_client`
 - `examples/swftb_sysv_spy.rs` as dylib (for LD_PRELOAD)
 - `device::Device::get_framebuffer_path(&self) -> &'static str`: Recommended to use in never versions as arg for `Framebuffer::from_path()`. Otherwise new swtfb_client will not be used automatically.

Breaking changes:
 - `get_fix_screeninfo`, `get_var_screeninfo`, `put_var_screeninfo` have got an additional parameter to work with swtfb_client. I doubt that anyone used such low level functions apart from me in plato.

Other changes:
 - Removed some duplicate code in `FramebufferRefresh`
 - Added new field `swtfb_client: Option<super::swtfb_client::SwtfbClient>` to `Framebuffer`

Note: With swtfb_client, FixScreeninfo->smem_start will not be set (= 0) since it's hard to do without splitting the `from_path` completely for both variants. Again I highly doubt that anyone used this. `Framebuffer.frame.as_ptr()` should return the correct value.