### PR TITLE
Impl Copy, Clone for all types in common.rs

### DIFF
--- a/src/framebuffer/common.rs
+++ b/src/framebuffer/common.rs
@@ -300,20 +300,20 @@ pub enum mxcfb_ioctl {
     MXCFB_ENABLE_EPDC_ACCESS = 0x36,
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug, PartialEq)]
 pub enum auto_update_mode {
     AUTO_UPDATE_MODE_REGION_MODE = 0,
     AUTO_UPDATE_MODE_AUTOMATIC_MODE = 1,
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum update_scheme {
     UPDATE_SCHEME_SNAPSHOT = 0,
     UPDATE_SCHEME_QUEUE = 1,
     UPDATE_SCHEME_QUEUE_AND_MERGE = 2,
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum update_mode {
     /// Returns a marker, no locking, no waiting on the
     /// clean state on the update region
@@ -324,7 +324,7 @@ pub enum update_mode {
     UPDATE_MODE_FULL = 1,
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum dither_mode {
     EPDC_FLAG_USE_DITHERING_PASSTHROUGH = 0x0,
     EPDC_FLAG_USE_DITHERING_DRAWING = 0x1,
@@ -344,7 +344,7 @@ pub enum dither_mode {
     EPDC_FLAG_EXP8 = 0x7ed3_d2c0,
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum waveform_mode {
     /// (Recommended) Screen goes to white
     /// (flashes black/white once to clear ghosting when used with UPDATE_MODE_FULL)
@@ -395,7 +395,7 @@ pub enum waveform_mode {
     WAVEFORM_MODE_AUTO = 257,
 }
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub enum display_temp {
     /// Seems to have the best draw latency. Perhaps the rule of thumb here is the lower the faster.
     /// `xochitl` seems to use this value.


### PR DESCRIPTION
This is a minor fix that allows to Copy and Clone all types in `src/framebuffer/common.rs`. More a minor thing to improve usability for some cases.

I originally stumbled upon this when doing [doomarkable](https://github.com/LinusCDE/doomarkable). Wanted to specify the waveform depending on the device and later reuse it depending on the model in a render loop. Problem was that the variable in loop wouldn't work, since the parameter is owned and rusts ownership wouldn't permit me to give ownership repeatedly away in a loop (duh).

Wouldn't be a problem if the waveform mode could be cloned or such, but this wasn't derive. So I would basically need to create my own clone, remember it otherwise (basically serializing to a different type (e.g. and int) deserializing it again every time). My workaround was to just find out the same value every time [in the loop](https://github.com/LinusCDE/doomarkable/blob/9b5785ba4a52679dfb39900b78a019bfa30b47ef/src/main.rs#L251) while it would be perfectly fine to do once [before the loop](https://github.com/LinusCDE/doomarkable/blob/9b5785ba4a52679dfb39900b78a019bfa30b47ef/src/main.rs#L189) (any maybe use a clone on that value if not also Copy).

Clone would be enough, but those types are pretty primitive and surely not worth the cloning. Also more complex types in the same file already had also "Copy" specifies. So I took the liberty to ensure that all types in that file have Copy and Clone.

For the next version, looking that everything is at least Debug'able and (in most cases) at Clone'able would probably be good as well. Just wanted to to this quick fix now since that note sat on my todo list ever since.

Maybe those types should also get PartialEq, Eq and Hash as well in case people would need it. Not sure what Rust's philosophy would be in such a case (better to "over-derive" or "under-derive"?).