### PR TITLE
Add a screenshot utility

### DIFF
--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -1,4 +1,5 @@
 use image::{DynamicImage, ImageOutputFormat};
+use libremarkable::device::CURRENT_DEVICE;
 use libremarkable::framebuffer::common::*;
 use libremarkable::framebuffer::core::*;
 use libremarkable::framebuffer::*;
@@ -6,7 +7,7 @@ use libremarkable::image::RgbImage;
 use std::fs::OpenOptions;
 
 fn main() {
-    let fb = Framebuffer::from_path("/dev/fb0");
+    let fb = Framebuffer::from_path(CURRENT_DEVICE.get_framebuffer_path());
     let width = DISPLAYWIDTH as u32;
     let height = DISPLAYHEIGHT as u32;
     let contents = fb

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -36,7 +36,7 @@ fn main() {
                 .expect("Invalid path provided as argument!");
             DynamicImage::ImageRgb8(image)
                 .write_to(&mut output_file, ImageOutputFormat::Png)
-                .expect("failed while writing to stdout");
+                .expect("failed while writing to output file");
         }
         None => {
             let mut stdout = std::io::stdout();

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -1,0 +1,48 @@
+use image::{DynamicImage, ImageOutputFormat};
+use libremarkable::framebuffer::common::*;
+use libremarkable::framebuffer::core::*;
+use libremarkable::framebuffer::*;
+use libremarkable::image::RgbImage;
+use std::fs::OpenOptions;
+
+fn main() {
+    let fb = Framebuffer::from_path("/dev/fb0");
+    let width = DISPLAYWIDTH as u32;
+    let height = DISPLAYHEIGHT as u32;
+    let contents = fb
+        .dump_region(mxcfb_rect {
+            top: 0,
+            left: 0,
+            width,
+            height,
+        })
+        .expect("dumping image buffer with known dimensions should succeed")
+        .chunks_exact(2)
+        .flat_map(|c| color::NATIVE_COMPONENTS(c[0], c[1]).to_rgb8())
+        .collect::<Vec<_>>();
+
+    let image =
+        RgbImage::from_raw(width, height, contents).expect("unable to construct the rgb image");
+
+    let args = std::env::args().collect::<Vec<_>>();
+
+    match args.get(1) {
+        Some(path) => {
+            let mut output_file = OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(false)
+                .open(path)
+                .expect("Invalid path provided as argument!");
+            DynamicImage::ImageRgb8(image)
+                .write_to(&mut output_file, ImageOutputFormat::Png)
+                .expect("failed while writing to stdout");
+        }
+        None => {
+            let mut stdout = std::io::stdout();
+            DynamicImage::ImageRgb8(image)
+                .write_to(&mut stdout, ImageOutputFormat::Png)
+                .expect("failed while writing to stdout");
+        }
+    }
+}


### PR DESCRIPTION
A quick screenshot script; it writes the screen contents as a PNG to the given path, or to stdout if no path is given.

This is a small amount of code, but seemed generally useful enough -- and a simple enough usage of the library -- to be worth contributing. But if y'all disagree I don't feel super strongly about it.