### PR TITLE
Fix rare segfault on wait_for_update

### DIFF
--- a/examples/swtfb_sysv_spy.rs
+++ b/examples/swtfb_sysv_spy.rs
@@ -25,7 +25,7 @@ hook! {
         eprintln!("Spy: msgsnd({:#x}, {:?}, {}, {:#x}) => {}", msqid, msgp, msgsz, msgflg, res);
         if msgsz == std::mem::size_of::<swtfb_client::swtfb_update>() {
             let msg = &*(msgp as *const swtfb_client::swtfb_update);
-                eprintln!("Spy: msgsnd: Message: swt_update.mtype: {:?}, data: ... }}", msg.mtype);
+                eprintln!("Spy: msgsnd: Message: {{ swt_update.mtype: {:?}, data: ... }}", msg.mtype);
                 let data_str_formatted = match msg.mtype {
                     swtfb_client::MSG_TYPE::INIT_t => {
                         format!("...")

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -156,6 +156,12 @@ impl SwtfbClient {
         self.send_wait_update(&wait_sem_data { sem_name });
         let sem_name_c = CString::new(sem_name_str.as_str()).unwrap();
         let sem = unsafe { libc::sem_open(sem_name_c.as_ptr(), libc::O_CREAT, 0x644, 0) };
+        if sem == libc::SEM_FAILED {
+            panic!(
+                "Opening semaphore to wait for swtfb update failed: {:?}",
+                unsafe { CStr::from_ptr(libc::strerror(*libc::__errno_location())) }
+            );
+        }
 
         let mut timeout = libc::timespec {
             tv_nsec: 0,

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -155,13 +155,7 @@ impl SwtfbClient {
         }
         self.send_wait_update(&wait_sem_data { sem_name });
         let sem_name_c = CString::new(sem_name_str.as_str()).unwrap();
-        let sem = unsafe { libc::sem_open(sem_name_c.as_ptr(), libc::O_CREAT, 0x644) };
-        if sem == libc::SEM_FAILED {
-            panic!(
-                "Opening semaphore to wait for swtfb update failed: {:?}",
-                unsafe { CStr::from_ptr(libc::strerror(*libc::__errno_location())) }
-            );
-        }
+        let sem = unsafe { libc::sem_open(sem_name_c.as_ptr(), libc::O_CREAT, 0x644, 0) };
 
         let mut timeout = libc::timespec {
             tv_nsec: 0,

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -161,7 +161,7 @@ impl SwtfbClient {
         // This adds some arbitrary delay should this happen.
         // This is really rare, but could be observed when using the lib
         // with plato, (probably exessive calls to wait() there).
-        let mut sem_open_attempts = 0usize;
+        let mut sem_open_attempts: u8 = 0;
         let sem = loop {
             let sem = unsafe { libc::sem_open(sem_name_c.as_ptr(), libc::O_CREAT) };
             sem_open_attempts += 1;

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -155,34 +155,13 @@ impl SwtfbClient {
         }
         self.send_wait_update(&wait_sem_data { sem_name });
         let sem_name_c = CString::new(sem_name_str.as_str()).unwrap();
-        // Make up to 3 attempts at sem_open
-        // The rust implemenation can be a little bit too fast,
-        // causing a SEM_FAILED result with errno = 22 ("Invalid value").
-        // This adds some arbitrary delay should this happen.
-        // This is really rare, but could be observed when using the lib
-        // with plato, (probably exessive calls to wait() there).
-        let mut sem_open_attempts: u8 = 0;
-        let sem = loop {
-            let sem = unsafe { libc::sem_open(sem_name_c.as_ptr(), libc::O_CREAT) };
-            sem_open_attempts += 1;
-            if sem == libc::SEM_FAILED {
-                // Attempt up to 3 times before failing
-                if sem_open_attempts <= 3 {
-                    log::debug!("Failed to open a semaphore to wait for swtfb update (attempt {} of 3). Waiting 5ms...", sem_open_attempts);
-                    std::thread::sleep(std::time::Duration::from_millis(5));
-                    continue;
-                } else {
-                    /*let cstr = CString::new("Opening semaphore to wait for swtfb update failed").unwrap();
-                    unsafe { libc::perror(cstr.as_ptr()) };*/
-                    panic!(
-                        "Opening semaphore to wait for swtfb update failed: {:?}",
-                        unsafe { CStr::from_ptr(libc::strerror(*libc::__errno_location())) }
-                    );
-                }
-            } else {
-                break sem;
-            }
-        };
+        let sem = unsafe { libc::sem_open(sem_name_c.as_ptr(), libc::O_CREAT, 0x644) };
+        if sem == libc::SEM_FAILED {
+            panic!(
+                "Opening semaphore to wait for swtfb update failed: {:?}",
+                unsafe { CStr::from_ptr(libc::strerror(*libc::__errno_location())) }
+            );
+        }
 
         let mut timeout = libc::timespec {
             tv_nsec: 0,


### PR DESCRIPTION
Found this, when using this implementation for plato:

![grafik](https://user-images.githubusercontent.com/22298664/146867667-9059323b-4ccb-431d-b35a-9199afc44627.png)

The cause was that `sem_timedwait` was called on `sem_open`'s result `SEM_FAILED`. That call failed with `errno == 22` ("Invalid value"). Seems that the rust code called the code too fast and and probably made more likely by more frequent wait()'s in plato due to the ui system. Plato uses a bus system for almost everything, so afaik, calls should never be happen in parallel.

The implemenation was 1:1 like the reference implementation. While this didn't ever happen on the official rm2fb client, the cause might still be interesting to investigate and could possibly hint to a problem in the original impl. (cc @raisjn)

Added a way to do several attempts with delays which should provide a good enough workaround. Also turned later occuring segfault into a proper panic, should 3 attempts/10ms delay be not enough for some app.