### PR TITLE
Framebuffer interface

### DIFF
--- a/examples/live.rs
+++ b/examples/live.rs
@@ -1,6 +1,6 @@
 use libremarkable::framebuffer;
 use libremarkable::framebuffer::core::Framebuffer;
-use libremarkable::framebuffer::{FramebufferIO};
+use libremarkable::framebuffer::FramebufferIO;
 use libremarkable::image;
 use std::io::BufWriter;
 use tiny_http::{Response, Server};

--- a/examples/live.rs
+++ b/examples/live.rs
@@ -1,6 +1,6 @@
 use libremarkable::framebuffer;
 use libremarkable::framebuffer::core::Framebuffer;
-use libremarkable::framebuffer::{FramebufferBase, FramebufferIO};
+use libremarkable::framebuffer::{FramebufferIO};
 use libremarkable::image;
 use std::io::BufWriter;
 use tiny_http::{Response, Server};

--- a/src/appctx.rs
+++ b/src/appctx.rs
@@ -85,9 +85,7 @@ impl<'a> ApplicationContext<'a> {
         on_wacom: fn(&mut ApplicationContext<'_>, WacomEvent),
         on_touch: fn(&mut ApplicationContext<'_>, MultitouchEvent),
     ) -> ApplicationContext<'static> {
-        let framebuffer = Box::new(core::Framebuffer::from_path(
-            crate::device::CURRENT_DEVICE.get_framebuffer_path(),
-        ));
+        let framebuffer = Box::new(core::Framebuffer::new());
         let yres = framebuffer.var_screen_info.yres;
         let xres = framebuffer.var_screen_info.xres;
 

--- a/src/appctx.rs
+++ b/src/appctx.rs
@@ -12,7 +12,6 @@ use crate::framebuffer::cgmath;
 use crate::framebuffer::common::*;
 use crate::framebuffer::core;
 use crate::framebuffer::refresh::PartialRefreshMode;
-use crate::framebuffer::FramebufferBase;
 use crate::framebuffer::FramebufferDraw;
 use crate::framebuffer::FramebufferRefresh;
 use crate::input::ev;

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -15,6 +15,12 @@ use crate::framebuffer::screeninfo::{FixScreeninfo, VarScreeninfo};
 use crate::framebuffer::swtfb_client::SwtfbClient;
 use crate::framebuffer::FramebufferBase;
 use crate::device;
+use crate::device::Model;
+
+pub enum FramebufferUpdate {
+    Ioctl,
+    Swtfb(SwtfbClient),
+}
 
 /// Framebuffer struct containing the state (latest update marker etc.)
 /// along with the var/fix screeninfo structs.
@@ -28,7 +34,7 @@ pub struct Framebuffer<'a> {
     /// like it has been done in `Framebuffer::new(..)`.
     pub var_screen_info: VarScreeninfo,
     pub fix_screen_info: FixScreeninfo,
-    pub swtfb_client: Option<super::swtfb_client::SwtfbClient>,
+    pub framebuffer_update: FramebufferUpdate,
 }
 
 unsafe impl<'a> Send for Framebuffer<'a> {}
@@ -38,46 +44,64 @@ impl<'a> Framebuffer<'a> {
 
     /// Create a new framebuffer instance, autodetecting the correct path.
     pub fn new() -> Framebuffer<'a> {
-        Framebuffer::from_path(device::CURRENT_DEVICE.get_framebuffer_path())
+        let device = &*device::CURRENT_DEVICE;
+        match device.model {
+            Model::Gen1 => {
+                Framebuffer::classic(device.get_framebuffer_path())
+            }
+            Model::Gen2 => {
+                Framebuffer::rm2fb(device.get_framebuffer_path())
+            }
+        }
     }
 
     pub fn classic(path: &str) -> Framebuffer<'a> {
-        Framebuffer::build(path, None)
+        Framebuffer::build(path, FramebufferUpdate::Ioctl)
     }
 
     pub fn rm2fb(path: &str) -> Framebuffer<'a> {
-        Framebuffer::build(path, Some(SwtfbClient::default()))
+        Framebuffer::build(path, FramebufferUpdate::Swtfb(SwtfbClient::default()))
     }
 
 
     #[deprecated = "Use `new` to autodetect the right update method based on your device version, or `classic` or `rm2fb` to choose one explicitly."]
     pub fn from_path(path_to_device: &str) -> Framebuffer<'a> {
         let swtfb_client = if path_to_device == crate::device::Model::Gen2.framebuffer_path() {
-            Some(SwtfbClient::default())
+            FramebufferUpdate::Swtfb(SwtfbClient::default())
         } else {
-            None
+            FramebufferUpdate::Ioctl
         };
 
         Framebuffer::build(path_to_device, swtfb_client)
     }
 
-    fn build(path_to_device: &str, swtfb_client: Option<SwtfbClient>) -> Framebuffer<'a> {
+    fn build(path_to_device: &str, framebuffer_update: FramebufferUpdate) -> Framebuffer<'a> {
 
-        let (device, mem_map) = if let Some(ref swtfb_client) = swtfb_client {
-            let (device, mem_map) = swtfb_client
-                .open_buffer()
-                .expect("Failed to open swtfb shared buffer");
-            (device, Some(mem_map))
-        } else {
-            let device = OpenOptions::new()
-                .read(true)
-                .write(true)
-                .open(path_to_device)
-                .unwrap();
-            (device, None)
+        let (device, mem_map) = match &framebuffer_update {
+            FramebufferUpdate::Ioctl => {
+                let device = OpenOptions::new()
+                    .read(true)
+                    .write(true)
+                    .open(path_to_device)
+                    .unwrap();
+                (device, None)
+            }
+            FramebufferUpdate::Swtfb(swtfb_client) => {
+                let (device, mem_map) = swtfb_client
+                    .open_buffer()
+                    .expect("Failed to open swtfb shared buffer");
+                (device, Some(mem_map))
+            }
         };
 
-        let mut var_screen_info = Framebuffer::get_var_screeninfo(&device, swtfb_client.as_ref());
+        let mut var_screen_info = match &framebuffer_update {
+            FramebufferUpdate::Ioctl => {
+                Framebuffer::get_var_screeninfo(&device)
+            }
+            FramebufferUpdate::Swtfb(c) => {
+                c.get_var_screeninfo()
+            }
+        };
         var_screen_info.xres = 1404;
         var_screen_info.yres = 1872;
         var_screen_info.rotate = 1;
@@ -94,9 +118,17 @@ impl<'a> Framebuffer<'a> {
         var_screen_info.vmode = 0; // FB_VMODE_NONINTERLACED
         var_screen_info.accel_flags = 0;
 
-        Framebuffer::put_var_screeninfo(&device, swtfb_client.as_ref(), &mut var_screen_info);
+        let fix_screen_info = match &framebuffer_update {
+            FramebufferUpdate::Ioctl => {
+                Framebuffer::put_var_screeninfo(&device, &mut var_screen_info);
+                Framebuffer::get_fix_screeninfo(&device)
+            }
+            FramebufferUpdate::Swtfb(c) => {
+                c.get_fix_screeninfo()
+            }
+        };
 
-        let fix_screen_info = Framebuffer::get_fix_screeninfo(&device, swtfb_client.as_ref());
+
         let frame_length = (fix_screen_info.line_length * var_screen_info.yres) as usize;
 
         let mem_map = if let Some(mem_map) = mem_map {
@@ -118,79 +150,70 @@ impl<'a> Framebuffer<'a> {
             default_font,
             var_screen_info,
             fix_screen_info,
-            swtfb_client,
+            framebuffer_update,
         }
     }
 }
 
 impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
     fn set_epdc_access(&mut self, state: bool) {
-        if self.swtfb_client.is_some() {
-            // Not caught/handled in rm2fb => noop
-            return;
+        match self.framebuffer_update {
+            FramebufferUpdate::Ioctl => {
+                unsafe {
+                    libc::ioctl(
+                        self.device.as_raw_fd(),
+                        if state {
+                            MXCFB_ENABLE_EPDC_ACCESS
+                        } else {
+                            MXCFB_DISABLE_EPDC_ACCESS
+                        },
+                    );
+                };
+            }
+            FramebufferUpdate::Swtfb(_) => {}
         }
-
-        unsafe {
-            libc::ioctl(
-                self.device.as_raw_fd(),
-                if state {
-                    MXCFB_ENABLE_EPDC_ACCESS
-                } else {
-                    MXCFB_DISABLE_EPDC_ACCESS
-                },
-            );
-        };
     }
 
     fn set_autoupdate_mode(&mut self, mode: u32) {
-        if self.swtfb_client.is_some() {
-            // https://github.com/ddvk/remarkable2-framebuffer/blob/1e288aa9/src/client/main.cpp#L137
-            // Is a noop in rm2fb
-            return;
+        match self.framebuffer_update {
+            FramebufferUpdate::Ioctl => {
+                let m = mode.to_owned();
+                unsafe {
+                    libc::ioctl(
+                        self.device.as_raw_fd(),
+                        MXCFB_SET_AUTO_UPDATE_MODE,
+                        &m as *const u32,
+                    );
+                };
+            }
+            FramebufferUpdate::Swtfb(_) => {}
         }
-
-        let m = mode.to_owned();
-        unsafe {
-            libc::ioctl(
-                self.device.as_raw_fd(),
-                MXCFB_SET_AUTO_UPDATE_MODE,
-                &m as *const u32,
-            );
-        };
     }
 
     fn set_update_scheme(&mut self, scheme: u32) {
-        if self.swtfb_client.is_some() {
-            // Not caught/handled in rm2fb => noop
-            return;
+        match self.framebuffer_update {
+            FramebufferUpdate::Ioctl => {
+                let s = scheme.to_owned();
+                unsafe {
+                    libc::ioctl(
+                        self.device.as_raw_fd(),
+                        MXCFB_SET_UPDATE_SCHEME,
+                        &s as *const u32,
+                    );
+                };
+            }
+            FramebufferUpdate::Swtfb(_) => {}
         }
-
-        let s = scheme.to_owned();
-        unsafe {
-            libc::ioctl(
-                self.device.as_raw_fd(),
-                MXCFB_SET_UPDATE_SCHEME,
-                &s as *const u32,
-            );
-        };
     }
 
-    fn get_fix_screeninfo(device: &File, swtfb_client: Option<&SwtfbClient>) -> FixScreeninfo {
-        if let Some(swtfb_client) = swtfb_client {
-            return swtfb_client.get_fix_screeninfo();
-        }
-
+    fn get_fix_screeninfo(device: &File) -> FixScreeninfo {
         let mut info: FixScreeninfo = Default::default();
         let result = unsafe { ioctl(device.as_raw_fd(), FBIOGET_FSCREENINFO, &mut info) };
         assert!(result == 0, "FBIOGET_FSCREENINFO failed");
         info
     }
 
-    fn get_var_screeninfo(device: &File, swtfb_client: Option<&SwtfbClient>) -> VarScreeninfo {
-        if let Some(swtfb_client) = swtfb_client {
-            return swtfb_client.get_var_screeninfo();
-        }
-
+    fn get_var_screeninfo(device: &File) -> VarScreeninfo {
         let mut info: VarScreeninfo = Default::default();
         let result = unsafe { ioctl(device.as_raw_fd(), FBIOGET_VSCREENINFO, &mut info) };
         assert!(result == 0, "FBIOGET_VSCREENINFO failed");
@@ -199,15 +222,8 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
 
     fn put_var_screeninfo(
         device: &std::fs::File,
-        swtfb_client: Option<&SwtfbClient>,
         var_screen_info: &mut VarScreeninfo,
     ) -> bool {
-        if swtfb_client.is_some() {
-            // https://github.com/ddvk/remarkable2-framebuffer/blob/1e288aa9/src/client/main.cpp#L214
-            // Is a noop in rm2fb
-            return true;
-        }
-
         let result = unsafe { ioctl(device.as_raw_fd(), FBIOPUT_VSCREENINFO, var_screen_info) };
         result == 0
     }
@@ -215,7 +231,6 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
     fn update_var_screeninfo(&mut self) -> bool {
         Self::put_var_screeninfo(
             &self.device,
-            self.swtfb_client.as_ref(),
             &mut self.var_screen_info,
         )
     }

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -46,7 +46,7 @@ impl<'a> Default for Framebuffer<'a> {
 }
 
 impl<'a> Framebuffer<'a> {
-    /// Create a new framebuffer instance, autodetecting the correct path.
+    /// Create a new framebuffer instance, autodetecting the correct update method.
     pub fn new() -> Framebuffer<'a> {
         let device = &*device::CURRENT_DEVICE;
         match device.model {
@@ -60,7 +60,7 @@ impl<'a> Framebuffer<'a> {
     ///
     /// This matches the pre-0.6.0 behaviour, and relies on the rm2fb client
     /// shim on RM2. `new` is generally preferred, though existing apps may
-    /// with to use this method to avoid some risk of changing behaviour.
+    /// wish to use this method to avoid some risk of changing behaviour.
     pub fn device(path: &str) -> Framebuffer<'a> {
         let device = OpenOptions::new()
             .read(true)
@@ -70,9 +70,10 @@ impl<'a> Framebuffer<'a> {
         Framebuffer::build(FramebufferUpdate::Ioctl(device))
     }
 
-    /// Uses the rm2fb interface for framebuffer metadata.
+    /// Uses the [rm2fb interface](https://github.com/ddvk/remarkable2-framebuffer)
+    /// ufor framebuffer metadata.
     ///
-    /// This will not work at all on rm1; consider using `new` to autodetect
+    /// This will not work at all on RM1; consider using `new` to autodetect
     /// the right interface for the current hardware.
     pub fn rm2fb() -> Framebuffer<'a> {
         Framebuffer::build(FramebufferUpdate::Swtfb(SwtfbClient::default()))

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -50,6 +50,7 @@ impl<'a> Framebuffer<'a> {
     }
 
 
+    #[deprecated = "Use `new` to autodetect the right update method based on your device version, or `classic` or `rm2fb` to choose one explicitly."]
     pub fn from_path(path_to_device: &str) -> Framebuffer<'a> {
         let swtfb_client = if path_to_device == crate::device::Model::Gen2.framebuffer_path() {
             Some(SwtfbClient::default())

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -73,7 +73,7 @@ impl<'a> Framebuffer<'a> {
 
     fn build(framebuffer_update: FramebufferUpdate) -> Framebuffer<'a> {
         let mut var_screen_info = match &framebuffer_update {
-            FramebufferUpdate::Ioctl(device) => Framebuffer::get_var_screeninfo(&device),
+            FramebufferUpdate::Ioctl(device) => Framebuffer::get_var_screeninfo(device),
             FramebufferUpdate::Swtfb(c) => c.get_var_screeninfo(),
         };
         var_screen_info.xres = 1404;
@@ -94,8 +94,8 @@ impl<'a> Framebuffer<'a> {
 
         let fix_screen_info = match &framebuffer_update {
             FramebufferUpdate::Ioctl(device) => {
-                Framebuffer::put_var_screeninfo(&device, &mut var_screen_info);
-                Framebuffer::get_fix_screeninfo(&device)
+                Framebuffer::put_var_screeninfo(device, &mut var_screen_info);
+                Framebuffer::get_fix_screeninfo(device)
             }
             FramebufferUpdate::Swtfb(c) => c.get_fix_screeninfo(),
         };
@@ -202,7 +202,7 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
     fn update_var_screeninfo(&mut self) -> bool {
         match &self.framebuffer_update {
             FramebufferUpdate::Ioctl(device) => {
-                Self::put_var_screeninfo(&device, &mut self.var_screen_info)
+                Self::put_var_screeninfo(device, &mut self.var_screen_info)
             }
             FramebufferUpdate::Swtfb(_) => true,
         }

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -144,15 +144,13 @@ impl framebuffer::FramebufferBase for Framebuffer {
     fn set_epdc_access(&mut self, state: bool) {
         match &self.framebuffer_update {
             FramebufferUpdate::Ioctl(device) => {
+                let request = if state {
+                    MXCFB_ENABLE_EPDC_ACCESS
+                } else {
+                    MXCFB_DISABLE_EPDC_ACCESS
+                };
                 unsafe {
-                    libc::ioctl(
-                        device.as_raw_fd(),
-                        if state {
-                            MXCFB_ENABLE_EPDC_ACCESS
-                        } else {
-                            MXCFB_DISABLE_EPDC_ACCESS
-                        },
-                    );
+                    libc::ioctl(device.as_raw_fd(), request);
                 };
             }
             FramebufferUpdate::Swtfb(_) => {}

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -119,13 +119,9 @@ pub trait FramebufferBase<'a> {
     /// Toggles update scheme
     fn set_update_scheme(&mut self, scheme: u32);
     /// Creates a FixScreeninfo struct and fills it using ioctl
-    fn get_fix_screeninfo(
-        device: &std::fs::File,
-    ) -> screeninfo::FixScreeninfo;
+    fn get_fix_screeninfo(device: &std::fs::File) -> screeninfo::FixScreeninfo;
     /// Creates a VarScreeninfo struct and fills it using ioctl
-    fn get_var_screeninfo(
-        device: &std::fs::File,
-    ) -> screeninfo::VarScreeninfo;
+    fn get_var_screeninfo(device: &std::fs::File) -> screeninfo::VarScreeninfo;
     /// Makes the proper ioctl call to set the VarScreenInfo.
     /// You must first update the contents of self.var_screen_info
     /// and then call this function.

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -121,19 +121,16 @@ pub trait FramebufferBase<'a> {
     /// Creates a FixScreeninfo struct and fills it using ioctl
     fn get_fix_screeninfo(
         device: &std::fs::File,
-        swtfb_client: Option<&swtfb_client::SwtfbClient>,
     ) -> screeninfo::FixScreeninfo;
     /// Creates a VarScreeninfo struct and fills it using ioctl
     fn get_var_screeninfo(
         device: &std::fs::File,
-        swtfb_client: Option<&swtfb_client::SwtfbClient>,
     ) -> screeninfo::VarScreeninfo;
     /// Makes the proper ioctl call to set the VarScreenInfo.
     /// You must first update the contents of self.var_screen_info
     /// and then call this function.
     fn put_var_screeninfo(
         device: &std::fs::File,
-        swtfb_client: Option<&swtfb_client::SwtfbClient>,
         var_screen_info: &mut screeninfo::VarScreeninfo,
     ) -> bool;
 

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -112,8 +112,6 @@ pub trait FramebufferDraw {
 
 pub mod core;
 pub trait FramebufferBase<'a> {
-    /// Creates a new instance of Framebuffer
-    fn from_path(path_to_device: &str) -> core::Framebuffer<'_>;
     /// Toggles the EPD Controller (see https://wiki.mobileread.com/wiki/EPD_controller)
     fn set_epdc_access(&mut self, state: bool);
     /// Toggles autoupdate mode

--- a/src/framebuffer/refresh.rs
+++ b/src/framebuffer/refresh.rs
@@ -6,8 +6,8 @@ use log::warn;
 use crate::framebuffer;
 use crate::framebuffer::common;
 use crate::framebuffer::core;
-use crate::framebuffer::mxcfb::*;
 use crate::framebuffer::core::FramebufferUpdate;
+use crate::framebuffer::mxcfb::*;
 
 pub enum PartialRefreshMode {
     DryRun,
@@ -48,9 +48,7 @@ impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
                 let pt: *const mxcfb_update_data = &whole;
                 (unsafe { libc::ioctl(device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt) }) >= 0
             }
-            FramebufferUpdate::Swtfb(swtfb_client) => {
-                swtfb_client.send_mxcfb_update(&whole)
-            }
+            FramebufferUpdate::Swtfb(swtfb_client) => swtfb_client.send_mxcfb_update(&whole),
         };
 
         if !update_succeeded {
@@ -129,9 +127,7 @@ impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
                 let pt: *const mxcfb_update_data = &whole;
                 (unsafe { libc::ioctl(device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt) }) >= 0
             }
-            FramebufferUpdate::Swtfb(swtfb_client) => {
-                swtfb_client.send_mxcfb_update(&whole)
-            }
+            FramebufferUpdate::Swtfb(swtfb_client) => swtfb_client.send_mxcfb_update(&whole),
         };
 
         if !update_succeeded {

--- a/src/framebuffer/refresh.rs
+++ b/src/framebuffer/refresh.rs
@@ -44,9 +44,9 @@ impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
         };
 
         let update_succeeded = match &self.framebuffer_update {
-            FramebufferUpdate::Ioctl => {
+            FramebufferUpdate::Ioctl(device) => {
                 let pt: *const mxcfb_update_data = &whole;
-                (unsafe { libc::ioctl(self.device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt) }) >= 0
+                (unsafe { libc::ioctl(device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt) }) >= 0
             }
             FramebufferUpdate::Swtfb(swtfb_client) => {
                 swtfb_client.send_mxcfb_update(&whole)
@@ -125,9 +125,9 @@ impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
         };
 
         let update_succeeded = match &self.framebuffer_update {
-            FramebufferUpdate::Ioctl => {
+            FramebufferUpdate::Ioctl(device) => {
                 let pt: *const mxcfb_update_data = &whole;
-                (unsafe { libc::ioctl(self.device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt) }) >= 0
+                (unsafe { libc::ioctl(device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt) }) >= 0
             }
             FramebufferUpdate::Swtfb(swtfb_client) => {
                 swtfb_client.send_mxcfb_update(&whole)
@@ -148,14 +148,14 @@ impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
 
     fn wait_refresh_complete(&self, update_marker: u32) -> u32 {
         match &self.framebuffer_update {
-            FramebufferUpdate::Ioctl => {
+            FramebufferUpdate::Ioctl(device) => {
                 let mut markerdata = mxcfb_update_marker_data {
                     update_marker,
                     collision_test: 0,
                 };
                 if (unsafe {
                     libc::ioctl(
-                        self.device.as_raw_fd(),
+                        device.as_raw_fd(),
                         common::MXCFB_WAIT_FOR_UPDATE_COMPLETE,
                         &mut markerdata,
                     )

--- a/src/framebuffer/refresh.rs
+++ b/src/framebuffer/refresh.rs
@@ -7,6 +7,7 @@ use crate::framebuffer;
 use crate::framebuffer::common;
 use crate::framebuffer::core;
 use crate::framebuffer::mxcfb::*;
+use crate::framebuffer::core::FramebufferUpdate;
 
 pub enum PartialRefreshMode {
     DryRun,
@@ -42,11 +43,14 @@ impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
             ..Default::default()
         };
 
-        let update_succeeded = if let Some(ref swtfb_client) = self.swtfb_client {
-            swtfb_client.send_mxcfb_update(&whole)
-        } else {
-            let pt: *const mxcfb_update_data = &whole;
-            (unsafe { libc::ioctl(self.device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt) }) >= 0
+        let update_succeeded = match &self.framebuffer_update {
+            FramebufferUpdate::Ioctl => {
+                let pt: *const mxcfb_update_data = &whole;
+                (unsafe { libc::ioctl(self.device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt) }) >= 0
+            }
+            FramebufferUpdate::Swtfb(swtfb_client) => {
+                swtfb_client.send_mxcfb_update(&whole)
+            }
         };
 
         if !update_succeeded {
@@ -120,11 +124,14 @@ impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
             ..Default::default()
         };
 
-        let update_succeeded = if let Some(ref swtfb_client) = self.swtfb_client {
-            swtfb_client.send_mxcfb_update(&whole)
-        } else {
-            let pt: *const mxcfb_update_data = &whole;
-            (unsafe { libc::ioctl(self.device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt) }) >= 0
+        let update_succeeded = match &self.framebuffer_update {
+            FramebufferUpdate::Ioctl => {
+                let pt: *const mxcfb_update_data = &whole;
+                (unsafe { libc::ioctl(self.device.as_raw_fd(), common::MXCFB_SEND_UPDATE, pt) }) >= 0
+            }
+            FramebufferUpdate::Swtfb(swtfb_client) => {
+                swtfb_client.send_mxcfb_update(&whole)
+            }
         };
 
         if !update_succeeded {
@@ -140,26 +147,29 @@ impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
     }
 
     fn wait_refresh_complete(&self, update_marker: u32) -> u32 {
-        if let Some(ref swtfb_client) = self.swtfb_client {
-            swtfb_client.wait_for_update_complete();
-            // Assume success
-            return 0;
+        match &self.framebuffer_update {
+            FramebufferUpdate::Ioctl => {
+                let mut markerdata = mxcfb_update_marker_data {
+                    update_marker,
+                    collision_test: 0,
+                };
+                if (unsafe {
+                    libc::ioctl(
+                        self.device.as_raw_fd(),
+                        common::MXCFB_WAIT_FOR_UPDATE_COMPLETE,
+                        &mut markerdata,
+                    )
+                }) < 0
+                {
+                    warn!("WAIT_FOR_UPDATE_COMPLETE failed");
+                }
+                markerdata.collision_test
+            }
+            FramebufferUpdate::Swtfb(swtfb_client) => {
+                swtfb_client.wait_for_update_complete();
+                // Assume success
+                0
+            }
         }
-
-        let mut markerdata = mxcfb_update_marker_data {
-            update_marker,
-            collision_test: 0,
-        };
-        if (unsafe {
-            libc::ioctl(
-                self.device.as_raw_fd(),
-                common::MXCFB_WAIT_FOR_UPDATE_COMPLETE,
-                &mut markerdata,
-            )
-        }) < 0
-        {
-            warn!("WAIT_FOR_UPDATE_COMPLETE failed");
-        }
-        markerdata.collision_test
     }
 }


### PR DESCRIPTION
This rearranges the public API slightly to be more explicit: the user can now call `Framebuffer::new` explicitly, or `::classic` or `::rm2fb` to pick a specific backend.

Internally, this switches to using an enum for the old/new backend. This should be about as efficient to the old option-based interface, but moving the file descriptor used for ioctls into the enum makes certain types of errors less likely. My actual motive was to try and add a noop backend to allow for easier testing, but I'll leave that for a followup.

Haven't tested this properly yet, so marking as draft. Interested in thoughts if anyone has them!