### PR TITLE
make Roboto optional

### DIFF
--- a/src/appctx.rs
+++ b/src/appctx.rs
@@ -28,7 +28,7 @@ unsafe impl<'a> Send for ApplicationContext<'a> {}
 unsafe impl<'a> Sync for ApplicationContext<'a> {}
 
 pub struct ApplicationContext<'a> {
-    framebuffer: Box<core::Framebuffer<'a>>,
+    framebuffer: Box<core::Framebuffer>,
     yres: u32,
     xres: u32,
 
@@ -83,7 +83,7 @@ impl Default for ApplicationContext<'static> {
 
         // Reluctantly resort to using a static global to associate the lua context with the
         // one and only framebuffer that's going to be used
-        unsafe { luaext::G_FB = res.framebuffer.deref_mut() as *mut core::Framebuffer<'_> };
+        unsafe { luaext::G_FB = res.framebuffer.deref_mut() as *mut core::Framebuffer };
 
         let mut nms = lua.empty_array("fb");
         // Clears and refreshes the entire screen
@@ -104,9 +104,9 @@ impl Default for ApplicationContext<'static> {
 }
 
 impl<'a> ApplicationContext<'a> {
-    pub fn get_framebuffer_ref(&mut self) -> &'static mut core::Framebuffer<'static> {
+    pub fn get_framebuffer_ref(&mut self) -> &'static mut core::Framebuffer {
         unsafe {
-            std::mem::transmute::<_, &'static mut core::Framebuffer<'static>>(
+            std::mem::transmute::<_, &'static mut core::Framebuffer>(
                 self.framebuffer.deref_mut(),
             )
         }

--- a/src/appctx.rs
+++ b/src/appctx.rs
@@ -106,9 +106,7 @@ impl Default for ApplicationContext<'static> {
 impl<'a> ApplicationContext<'a> {
     pub fn get_framebuffer_ref(&mut self) -> &'static mut core::Framebuffer {
         unsafe {
-            std::mem::transmute::<_, &'static mut core::Framebuffer>(
-                self.framebuffer.deref_mut(),
-            )
+            std::mem::transmute::<_, &'static mut core::Framebuffer>(self.framebuffer.deref_mut())
         }
     }
 

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -20,7 +20,6 @@ pub struct Framebuffer<'a> {
     pub device: File,
     pub frame: MmapRaw,
     pub marker: AtomicU32,
-    pub default_font: Font<'a>,
     /// Not updated as a result of calling `Framebuffer::put_var_screeninfo(..)`.
     /// It is your responsibility to update this when you call into that function
     /// like it has been done in `Framebuffer::new(..)`.
@@ -85,14 +84,10 @@ impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
                 .expect("Unable to map provided path")
         };
 
-        // Load the font
-        let font_data = include_bytes!("../../assets/Roboto-Regular.ttf");
-        let default_font = Font::try_from_bytes(font_data as &[u8]).expect("corrupted font data");
         Framebuffer {
             marker: AtomicU32::new(1),
             device,
             frame: mem_map,
-            default_font,
             var_screen_info,
             fix_screen_info,
             swtfb_client,

--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -1,6 +1,5 @@
 use libc::ioctl;
 use memmap2::{MmapOptions, MmapRaw};
-use rusttype::Font;
 
 use std::fs::{File, OpenOptions};
 use std::os::unix::io::AsRawFd;
@@ -16,7 +15,7 @@ use crate::framebuffer::swtfb_client::SwtfbClient;
 
 /// Framebuffer struct containing the state (latest update marker etc.)
 /// along with the var/fix screeninfo structs.
-pub struct Framebuffer<'a> {
+pub struct Framebuffer {
     pub device: File,
     pub frame: MmapRaw,
     pub marker: AtomicU32,
@@ -28,11 +27,11 @@ pub struct Framebuffer<'a> {
     pub swtfb_client: Option<super::swtfb_client::SwtfbClient>,
 }
 
-unsafe impl<'a> Send for Framebuffer<'a> {}
-unsafe impl<'a> Sync for Framebuffer<'a> {}
+unsafe impl Send for Framebuffer {}
+unsafe impl Sync for Framebuffer {}
 
-impl<'a> framebuffer::FramebufferBase<'a> for Framebuffer<'a> {
-    fn from_path(path_to_device: &str) -> Framebuffer<'_> {
+impl framebuffer::FramebufferBase for Framebuffer {
+    fn from_path(path_to_device: &str) -> Framebuffer {
         let swtfb_client = if path_to_device == crate::device::Model::Gen2.framebuffer_path() {
             Some(SwtfbClient::default())
         } else {

--- a/src/framebuffer/draw.rs
+++ b/src/framebuffer/draw.rs
@@ -1,6 +1,6 @@
 use image::RgbImage;
 use once_cell::sync::Lazy;
-use rusttype::{Font, point, Scale};
+use rusttype::{point, Font, Scale};
 
 use crate::framebuffer;
 use crate::framebuffer::cgmath::*;
@@ -9,10 +9,10 @@ use crate::framebuffer::core;
 use crate::framebuffer::graphics;
 use crate::framebuffer::FramebufferIO;
 
-pub static DEFAULT_FONT: Lazy<Font<'static>> = Lazy::new(||
+pub static DEFAULT_FONT: Lazy<Font<'static>> = Lazy::new(|| {
     Font::try_from_bytes(include_bytes!("../../assets/Roboto-Regular.ttf").as_slice())
         .expect("corrupted font data")
-);
+});
 
 impl<'a> framebuffer::FramebufferDraw for core::Framebuffer {
     fn draw_image(&mut self, img: &RgbImage, pos: Point2<i32>) -> mxcfb_rect {

--- a/src/framebuffer/draw.rs
+++ b/src/framebuffer/draw.rs
@@ -1,5 +1,6 @@
 use image::RgbImage;
-use rusttype::{point, Scale};
+use once_cell::sync::Lazy;
+use rusttype::{Font, point, Scale};
 
 use crate::framebuffer;
 use crate::framebuffer::cgmath::*;
@@ -7,6 +8,11 @@ use crate::framebuffer::common::*;
 use crate::framebuffer::core;
 use crate::framebuffer::graphics;
 use crate::framebuffer::FramebufferIO;
+
+pub static DEFAULT_FONT: Lazy<Font<'static>> = Lazy::new(||
+    Font::try_from_bytes(include_bytes!("../../assets/Roboto-Regular.ttf").as_slice())
+        .expect("corrupted font data")
+);
 
 impl<'a> framebuffer::FramebufferDraw for core::Framebuffer<'a> {
     fn draw_image(&mut self, img: &RgbImage, pos: Point2<i32>) -> mxcfb_rect {
@@ -145,8 +151,6 @@ impl<'a> framebuffer::FramebufferDraw for core::Framebuffer<'a> {
         // The starting positioning of the glyphs (top left corner)
         let start = point(pos.x, pos.y);
 
-        let dfont = &mut self.default_font.clone();
-
         let mut min_y = pos.y.floor().max(0.0) as u32;
         let mut max_y = pos.y.ceil().max(0.0) as u32;
         let mut min_x = pos.x.floor().max(0.0) as u32;
@@ -158,7 +162,7 @@ impl<'a> framebuffer::FramebufferDraw for core::Framebuffer<'a> {
         let c3 = f32::from(255 - components[2]);
 
         // Loop through the glyphs in the text, positing each one on a line
-        for glyph in dfont.layout(text, scale, start) {
+        for glyph in DEFAULT_FONT.layout(text, scale, start) {
             if let Some(bounding_box) = glyph.pixel_bounding_box() {
                 // Draw the glyph into the image per-pixel by using the draw closure
                 let bbmax_y = bounding_box.max.y as u32;

--- a/src/framebuffer/draw.rs
+++ b/src/framebuffer/draw.rs
@@ -14,7 +14,7 @@ pub static DEFAULT_FONT: Lazy<Font<'static>> = Lazy::new(||
         .expect("corrupted font data")
 );
 
-impl<'a> framebuffer::FramebufferDraw for core::Framebuffer<'a> {
+impl<'a> framebuffer::FramebufferDraw for core::Framebuffer {
     fn draw_image(&mut self, img: &RgbImage, pos: Point2<i32>) -> mxcfb_rect {
         for (x, y, pixel) in img.enumerate_pixels() {
             let pixel_pos = pos + vec2(x as i32, y as i32);

--- a/src/framebuffer/io.rs
+++ b/src/framebuffer/io.rs
@@ -4,7 +4,7 @@ use crate::framebuffer;
 use crate::framebuffer::cgmath;
 use crate::framebuffer::common;
 
-impl<'a> framebuffer::FramebufferIO for framebuffer::core::Framebuffer<'a> {
+impl<'a> framebuffer::FramebufferIO for framebuffer::core::Framebuffer {
     fn write_frame(&mut self, frame: &[u8]) {
         let begin = self.frame.as_mut_ptr();
         unsafe {

--- a/src/framebuffer/mod.rs
+++ b/src/framebuffer/mod.rs
@@ -111,9 +111,9 @@ pub trait FramebufferDraw {
 }
 
 pub mod core;
-pub trait FramebufferBase<'a> {
+pub trait FramebufferBase {
     /// Creates a new instance of Framebuffer
-    fn from_path(path_to_device: &str) -> core::Framebuffer<'_>;
+    fn from_path(path_to_device: &str) -> core::Framebuffer;
     /// Toggles the EPD Controller (see https://wiki.mobileread.com/wiki/EPD_controller)
     fn set_epdc_access(&mut self, state: bool);
     /// Toggles autoupdate mode

--- a/src/framebuffer/refresh.rs
+++ b/src/framebuffer/refresh.rs
@@ -14,7 +14,7 @@ pub enum PartialRefreshMode {
     Wait,
 }
 
-impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer<'a> {
+impl<'a> framebuffer::FramebufferRefresh for core::Framebuffer {
     fn full_refresh(
         &self,
         waveform_mode: common::waveform_mode,

--- a/src/ui_extensions/luaext.rs
+++ b/src/ui_extensions/luaext.rs
@@ -10,12 +10,12 @@ use crate::framebuffer::FramebufferRefresh;
 
 /// We reluctantly resort to a static global here to associate the lua context
 /// with the only active framebuffer we will have
-pub static mut G_FB: *mut core::Framebuffer<'_> = std::ptr::null_mut();
+pub static mut G_FB: *mut core::Framebuffer = std::ptr::null_mut();
 
 /// A macro to utilize this static global only inside this file.
 macro_rules! get_current_framebuffer {
     () => {
-        unsafe { &mut *(G_FB as *mut core::Framebuffer<'_>) }
+        unsafe { &mut *(G_FB as *mut core::Framebuffer) }
     };
 }
 


### PR DESCRIPTION
This means you won't pay the cost of

- font storage in the binary
- up-front font parsing at runtime
- storage of the parsed structures at runtime

if you don't use the built-in font drawing code.