### PR TITLE
Add more image formats to "live" example and a html selection page

### DIFF
--- a/examples/live.rs
+++ b/examples/live.rs
@@ -46,14 +46,14 @@ fn main() {
             &rgb565,
         )
         .unwrap();
-        let url = request.url().to_lowercase();
-        let (data, mime) = if url.ends_with("jpg") || url.ends_with("jpeg") {
+        let url_lc = request.url().to_lowercase();
+        let (data, mime) = if url_lc.ends_with("jpg") || url_lc.ends_with("jpeg") {
             (encode(&*&rgb888, ImageFormat::Jpeg), "image/jpeg")
-        } else if url.ends_with("gif") {
+        } else if url_lc.ends_with("gif") {
             (encode(&*&rgb888, ImageFormat::Gif), "image/gif")
-        } else if url.ends_with("bmp") {
+        } else if url_lc.ends_with("bmp") {
             (encode(&*&rgb888, ImageFormat::Bmp), "image/bmp")
-        } else if url.ends_with("tga") {
+        } else if url_lc.ends_with("tga") {
             (encode(&*&rgb888, ImageFormat::Tga), "image/x-tga")
         } else {
             (encode(&*&rgb888, ImageFormat::Png), "image/png")
@@ -78,14 +78,14 @@ fn encode(img_buf: &[u8], format: ImageFormat) -> Vec<u8> {
         _ => unimplemented!(),
     }
     .unwrap();
-    let res = writer.into_inner();
+    let encoded = writer.into_inner();
     println!(
         "Encoded screenshot as {:?} in {:?} resulting in a file of {} KiB",
         format,
         start.elapsed(),
-        res.len() / 1024
+        encoded.len() / 1024
     );
-    res
+    encoded
 }
 
 const INDEX_PAGE: &str = r#"<!DOCTYPE html>

--- a/examples/live.rs
+++ b/examples/live.rs
@@ -7,7 +7,7 @@ use libremarkable::framebuffer::common::{DISPLAYHEIGHT, DISPLAYWIDTH};
 use libremarkable::framebuffer::core::Framebuffer;
 use libremarkable::framebuffer::FramebufferIO;
 use libremarkable::image;
-use std::io::BufWriter;
+use std::io::Cursor;
 use tiny_http::{Header, Response, Server, StatusCode};
 
 /// An HTTP server that listens on :8000 and responds to all incoming requests
@@ -61,7 +61,7 @@ fn main() {
 
 fn encode(img_buf: &[u8], format: ImageFormat) -> Vec<u8> {
     let (width, height) = (DISPLAYWIDTH.into(), DISPLAYHEIGHT.into());
-    let mut writer = BufWriter::new(Vec::new());
+    let mut writer = Cursor::new(Vec::new());
     match format {
         ImageFormat::Bmp => BmpEncoder::new(&mut writer).encode(img_buf, width, height, Rgb8),
         ImageFormat::Gif => GifEncoder::new(&mut writer).encode(img_buf, width, height, Rgb8),
@@ -71,5 +71,5 @@ fn encode(img_buf: &[u8], format: ImageFormat) -> Vec<u8> {
         _ => unimplemented!(),
     }
     .unwrap();
-    writer.into_inner().unwrap()
+    writer.into_inner()
 }

--- a/examples/live.rs
+++ b/examples/live.rs
@@ -60,6 +60,7 @@ fn main() {
 }
 
 fn encode(img_buf: &[u8], format: ImageFormat) -> Vec<u8> {
+    let start = std::time::Instant::now();
     let (width, height) = (DISPLAYWIDTH.into(), DISPLAYHEIGHT.into());
     let mut writer = Cursor::new(Vec::new());
     match format {
@@ -71,5 +72,12 @@ fn encode(img_buf: &[u8], format: ImageFormat) -> Vec<u8> {
         _ => unimplemented!(),
     }
     .unwrap();
-    writer.into_inner()
+    let res = writer.into_inner();
+    println!(
+        "Encoded screenshot as {:?} in {:?} resulting in a file of {} KiB",
+        format,
+        start.elapsed(),
+        res.len() / 1024
+    );
+    res
 }

--- a/examples/live.rs
+++ b/examples/live.rs
@@ -24,6 +24,12 @@ fn main() {
             request.respond(Response::empty(404)).unwrap();
             continue;
         }
+        if request.url() == "/" {
+            let response = Response::from_string(INDEX_PAGE)
+                .with_header("Content-Type: text/html".parse::<Header>().unwrap());
+            request.respond(response).unwrap();
+            continue;
+        }
 
         let rgb565 = fb
             .dump_region(framebuffer::common::mxcfb_rect {
@@ -81,3 +87,46 @@ fn encode(img_buf: &[u8], format: ImageFormat) -> Vec<u8> {
     );
     res
 }
+
+const INDEX_PAGE: &str = r#"<!DOCTYPE html>
+<html>
+    <head>
+        <title>libremarkable example: live</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style>
+            body {
+                background-color: #f0f0f0;
+                display: flex;
+                flex-direction: column;
+                align-items: center;
+            }
+            body > p {
+                text-align: center;
+            }
+            a {
+                text-decoration: inherit;
+                color: inherit;
+                border: 2px solid gray;
+                margin-bottom: 5px;
+                padding: 3px 3px;
+                transition-duration: 0.2s;
+            }
+            a:hover {
+                box-shadow: 0px 0px 2px rgba(0, 0, 0, 0.8);
+                transition-duration: 0.2s;
+            }
+            body > * {
+                width: 100%;
+                max-width: 440px;
+            }
+        </style>
+    </head>
+        <p><b>Create screenshot as</b></p>
+        <a href="/png">PNG<br><small>Lossless, fast and small when few realistic graphics included.</small></a>
+        <a href="/jpg">JPG<br><small>Lossy, slower and usually smaller, can add noise in UIs.</small></a>
+        <a href="/gif">GIF<br><small>Lossless, very small and slow. Reduced colour pallete.</small></a>
+        <a href="/tga">TGA<br><small>Lossless, huge and fast. Usually slowest due to speed, but raw.</small></a>
+        <small>You can save the image by right clicking or holding the image and selecting <i>Save image</i></small>
+    </body>
+</html>
+"#;


### PR DESCRIPTION
I usually used a "livepng" version where I replaced the "JpegEncoder" with an "PngEncoder" since the images where usually smaller and lossless for my usecases (usually screenshots for READMEs in my projects).

Started this out with the intend to add png support alongside jpeg. Since we're using a webserver, I also decided to add a minimal html page to allow users to choose what format to use. Also checked that it renders okay on smartphones.

<img src="https://user-images.githubusercontent.com/22298664/149809087-64f7b245-d53d-4db8-90c3-80fddef404cd.png" width="50%">

You can also now see the duration of the encoding in the console.
![grafik](https://user-images.githubusercontent.com/22298664/149808924-5c8e7a8b-a625-4421-b97c-6671496e6bdb.png)
