### PR TITLE
Make rgb565 conversion algorithms a bit better

### DIFF
--- a/src/framebuffer/common.rs
+++ b/src/framebuffer/common.rs
@@ -110,12 +110,12 @@ impl color {
 #[test]
 fn rgb565_conversions() {
     // Ensure that min and max values are transformed faithfully
-    assert_eq!(color::RGB(0, 0, 0).to_rgb565(), [0x0, 0x0]);
+    assert_eq!(color::RGB(0, 0, 0).to_rgb565(), [0, 0]);
     assert_eq!(color::RGB(255, 255, 255).to_rgb565(), [255, 255]);
     assert_eq!(color::from_native([0, 0]).to_rgb8(), [0, 0, 0]);
     assert_eq!(color::from_native([255, 255]).to_rgb8(), [255, 255, 255]);
     assert_eq!(color::GRAY(0).to_rgb565(), [255, 255]);
-    assert_eq!(color::GRAY(255).to_rgb565(), [0x0, 0x0]);
+    assert_eq!(color::GRAY(255).to_rgb565(), [0, 0]);
 
     // Ensure that every single RGB565 value can be transformed to RGB8 and back losslessly
     for native in 0..u16::MAX {

--- a/src/framebuffer/common.rs
+++ b/src/framebuffer/common.rs
@@ -60,11 +60,11 @@ impl color {
     }
 
     pub fn to_rgb8(self) -> [u8; 3] {
-        let rgb565 = u16::from_be_bytes(self.as_native());
+        let rgb565 = u16::from_le_bytes(self.as_native());
 
-        let r5 = rgb565 & 0b11111;
+        let r5 = rgb565 >> 11 & 0b11111;
         let g6 = rgb565 >> 5 & 0b111111;
-        let b5 = rgb565 >> 11 & 0b11111;
+        let b5 = rgb565 & 0b11111;
 
         let r8 = (r5 * 255 / 0b11111) as u8;
         let g8 = (g6 * 255 / 0b111111) as u8;
@@ -77,9 +77,9 @@ impl color {
     pub fn as_native(self) -> [u8; 2] {
         match self {
             color::BLACK => [0x00, 0x00],
-            color::RED => [0x00, 0x1F],
-            color::GREEN => [0x07, 0xE0],
-            color::BLUE => [0xF8, 0x00],
+            color::RED => [0x00, 0xF8],
+            color::GREEN => [0xE0, 0x07],
+            color::BLUE => [0x1F, 0x00],
             color::WHITE => [0xFF, 0xFF],
             color::GRAY(level) => color::rgb_to_native(255 - level, 255 - level, 255 - level),
             color::NATIVE_COMPONENTS(c1, c2) => [c1, c2],
@@ -101,9 +101,9 @@ impl color {
         let g6 = (g8 as u16 + 1) * 0b111111 / 255;
         let b5 = (b8 as u16 + 1) * 0b11111 / 255;
 
-        let rgb565 = b5 << 11 | g6 << 5 | r5;
+        let rgb565 = r5 << 11 | g6 << 5 | b5;
 
-        rgb565.to_be_bytes()
+        rgb565.to_le_bytes()
     }
 }
 
@@ -124,7 +124,7 @@ fn rgb565_conversions() {
 
     // Ensure that every single RGB565 value can be transformed to RGB8 and back losslessly
     for native in 0..u16::MAX {
-        let [lo, hi] = native.to_be_bytes();
+        let [lo, hi] = native.to_le_bytes();
         let [r, g, b] = color::NATIVE_COMPONENTS(lo, hi).to_rgb8();
 
         assert_eq!(color::RGB(r, g, b).to_rgb565(), [lo, hi]);

--- a/src/framebuffer/common.rs
+++ b/src/framebuffer/common.rs
@@ -60,7 +60,7 @@ impl color {
     }
 
     pub fn to_rgb8(self) -> [u8; 3] {
-        let rgb565 = u16::from_le_bytes(self.as_native());
+        let rgb565 = u16::from_be_bytes(self.as_native());
 
         let r5 = rgb565 & 0b11111;
         let g6 = rgb565 >> 5 & 0b111111;
@@ -77,8 +77,8 @@ impl color {
     pub fn as_native(self) -> [u8; 2] {
         match self {
             color::BLACK => [0x00, 0x00],
-            color::RED => [0x07, 0xE0],
-            color::GREEN => [0x00, 0x1F],
+            color::RED => [0x00, 0x1F],
+            color::GREEN => [0x07, 0xE0],
             color::BLUE => [0xF8, 0x00],
             color::WHITE => [0xFF, 0xFF],
             color::GRAY(level) => color::rgb_to_native(255 - level, 255 - level, 255 - level),
@@ -103,7 +103,7 @@ impl color {
 
         let rgb565 = b5 << 11 | g6 << 5 | r5;
 
-        rgb565.to_le_bytes()
+        rgb565.to_be_bytes()
     }
 }
 
@@ -112,10 +112,15 @@ fn rgb565_conversions() {
     // Ensure that min and max values are transformed faithfully
     assert_eq!(color::RGB(0, 0, 0).to_rgb565(), [0, 0]);
     assert_eq!(color::RGB(255, 255, 255).to_rgb565(), [255, 255]);
-    assert_eq!(color::from_native([0, 0]).to_rgb8(), [0, 0, 0]);
-    assert_eq!(color::from_native([255, 255]).to_rgb8(), [255, 255, 255]);
     assert_eq!(color::GRAY(0).to_rgb565(), [255, 255]);
     assert_eq!(color::GRAY(255).to_rgb565(), [0, 0]);
+
+    assert_eq!(color::from_native([0, 0]).to_rgb8(), [0, 0, 0]);
+    assert_eq!(color::from_native([255, 255]).to_rgb8(), [255, 255, 255]);
+    assert_eq!(color::BLUE.to_rgb8(), [0, 0, 255]);
+    assert_eq!(color::GREEN.to_rgb8(), [0, 255, 0]);
+    assert_eq!(color::RED.to_rgb8(), [255, 0, 0]);
+    assert_eq!(color::RGB(255, 127, 0).to_rgb8(), [255, 125, 0]);
 
     // Ensure that every single RGB565 value can be transformed to RGB8 and back losslessly
     for native in 0..u16::MAX {

--- a/src/framebuffer/common.rs
+++ b/src/framebuffer/common.rs
@@ -112,6 +112,8 @@ fn rgb565_conversions() {
     // Ensure that min and max values are transformed faithfully
     assert_eq!(color::RGB(0, 0, 0).to_rgb565(), [0x0, 0x0]);
     assert_eq!(color::RGB(255, 255, 255).to_rgb565(), [0xFF, 0xFF]);
+    assert_eq!(color::from_native([0, 0]).to_rgb8(), [0, 0, 0]);
+    assert_eq!(color::from_native([0xFF, 0xFF]).to_rgb8(), [0xFF, 0xFF, 0xFF]);
     assert_eq!(color::GRAY(0).to_rgb565(), [0xFF, 0xFF]);
     assert_eq!(color::GRAY(255).to_rgb565(), [0x0, 0x0]);
 

--- a/src/framebuffer/common.rs
+++ b/src/framebuffer/common.rs
@@ -108,6 +108,23 @@ impl color {
     }
 }
 
+#[test]
+fn rgb565_conversions() {
+    // Ensure that min and max values are transformed faithfully
+    assert_eq!(color::RGB(0, 0, 0).to_rgb565(), [0x0, 0x0]);
+    assert_eq!(color::RGB(255, 255, 255).to_rgb565(), [0xFF, 0xFF]);
+    assert_eq!(color::GRAY(0).to_rgb565(), [0xFF, 0xFF]);
+    assert_eq!(color::GRAY(255).to_rgb565(), [0x0, 0x0]);
+
+    // Ensure that every single RGB565 value can be transformed to RGB8 and back losslessly
+    for native in 0..u16::MAX {
+        let [lo, hi] = native.to_be_bytes();
+        let [r, g, b] = color::NATIVE_COMPONENTS(lo, hi).to_rgb8();
+
+        assert_eq!(color::RGB(r, g, b).to_rgb565(), [lo, hi]);
+    }
+}
+
 impl ::std::default::Default for color {
     fn default() -> Self {
         color::WHITE

--- a/src/framebuffer/common.rs
+++ b/src/framebuffer/common.rs
@@ -60,11 +60,11 @@ impl color {
     }
 
     pub fn to_rgb8(self) -> [u8; 3] {
-        let rgb565 = u16::from_be_bytes(self.as_native());
+        let rgb565 = u16::from_le_bytes(self.as_native());
 
-        let r5 = rgb565 >> 11 & 0b11111;
+        let r5 = rgb565 & 0b11111;
         let g6 = rgb565 >> 5 & 0b111111;
-        let b5 = rgb565 & 0b11111;
+        let b5 = rgb565 >> 11 & 0b11111;
 
         let r8 = (r5 * 255 / 0b11111) as u8;
         let g8 = (g6 * 255 / 0b111111) as u8;
@@ -101,9 +101,9 @@ impl color {
         let g6 = (g8 as u16 + 1) * 0b111111 / 255;
         let b5 = (b8 as u16 + 1) * 0b11111 / 255;
 
-        let rgb565 = r5 << 11 | g6 << 5 | b5;
+        let rgb565 = b5 << 11 | g6 << 5 | r5;
 
-        rgb565.to_be_bytes()
+        rgb565.to_le_bytes()
     }
 }
 

--- a/src/framebuffer/common.rs
+++ b/src/framebuffer/common.rs
@@ -111,10 +111,10 @@ impl color {
 fn rgb565_conversions() {
     // Ensure that min and max values are transformed faithfully
     assert_eq!(color::RGB(0, 0, 0).to_rgb565(), [0x0, 0x0]);
-    assert_eq!(color::RGB(255, 255, 255).to_rgb565(), [0xFF, 0xFF]);
+    assert_eq!(color::RGB(255, 255, 255).to_rgb565(), [255, 255]);
     assert_eq!(color::from_native([0, 0]).to_rgb8(), [0, 0, 0]);
-    assert_eq!(color::from_native([0xFF, 0xFF]).to_rgb8(), [0xFF, 0xFF, 0xFF]);
-    assert_eq!(color::GRAY(0).to_rgb565(), [0xFF, 0xFF]);
+    assert_eq!(color::from_native([255, 255]).to_rgb8(), [255, 255, 255]);
+    assert_eq!(color::GRAY(0).to_rgb565(), [255, 255]);
     assert_eq!(color::GRAY(255).to_rgb565(), [0x0, 0x0]);
 
     // Ensure that every single RGB565 value can be transformed to RGB8 and back losslessly


### PR DESCRIPTION
The old algorithm has some unpleasant tinting. Native components `[0xFF, 0xFF]` don't result in rgb components `[0xFF, 0xFF, 0xFF]` but rather `[0xF8, 0xFC, 0xF8]`. This affects screenshots for example.

Obviously some fudging is needed in order to come up with the "extra resolution" in rgb8 to make the mins and maxes match up. Roundtripping from 565 -> 888 -> 565 is still a thing. And now it's a part of the test suite, which verifies that every rgb565 value can be roundtripped to rgb8 and back. And that rgb565 -> rgb8 conversions behave properly.

The new conversion routines still only use integer arithmetic. I haven't benchmarked them but they should actually be slightly faster than the old routines.

Note that I tested these on my desktop machine which required #92 in order to get libremarkable to build. Just a preview of how useful that can be.