### PR TITLE
Switch to using touch state instead of most recent event

### DIFF
--- a/src/input/wacom.rs
+++ b/src/input/wacom.rs
@@ -22,7 +22,7 @@ pub struct WacomState {
     last_ytilt: AtomicU16,
     last_dist: AtomicU16,
     last_pressure: AtomicU16,
-    last_tool: Atomic<Option<WacomPen>>,
+    last_touch_state: Atomic<bool>,
 }
 
 impl ::std::default::Default for WacomState {
@@ -34,7 +34,7 @@ impl ::std::default::Default for WacomState {
             last_ytilt: AtomicU16::new(0),
             last_dist: AtomicU16::new(0),
             last_pressure: AtomicU16::new(0),
-            last_tool: Atomic::new(None),
+            last_touch_state: Atomic::new(false),
         }
     }
 }
@@ -88,8 +88,8 @@ pub fn decode(ev: &EvInputEvent, outer_state: &InputDeviceState) -> Option<Input
         _ => unreachable!(),
     };
     match ev.event_type().0 {
-        ecodes::EV_SYN => match state.last_tool.load(Ordering::Relaxed) {
-            Some(WacomPen::ToolPen) => Some(InputEvent::WacomEvent {
+        ecodes::EV_SYN => match state.last_touch_state.load(Ordering::Relaxed) {
+            false => Some(InputEvent::WacomEvent {
                 event: WacomEvent::Hover {
                     position: cgmath::Point2 {
                         x: (f32::from(state.last_x.load(Ordering::Relaxed)) * *WACOM_HSCALAR),
@@ -102,7 +102,7 @@ pub fn decode(ev: &EvInputEvent, outer_state: &InputDeviceState) -> Option<Input
                     },
                 },
             }),
-            Some(WacomPen::Touch) => Some(InputEvent::WacomEvent {
+            true => Some(InputEvent::WacomEvent {
                 event: WacomEvent::Draw {
                     position: cgmath::Point2 {
                         x: (f32::from(state.last_x.load(Ordering::Relaxed)) * *WACOM_HSCALAR),
@@ -115,7 +115,6 @@ pub fn decode(ev: &EvInputEvent, outer_state: &InputDeviceState) -> Option<Input
                     },
                 },
             }),
-            _ => None,
         },
         ecodes::EV_KEY => {
             /* key (device detected - device out of range etc.) */
@@ -124,12 +123,16 @@ pub fn decode(ev: &EvInputEvent, outer_state: &InputDeviceState) -> Option<Input
             }
 
             let pen: WacomPen = unsafe { std::mem::transmute_copy(&ev.code()) };
-            state.last_tool.store(Some(pen), Ordering::Relaxed);
+            let pen_state = ev.value() != 0;
+
+            if pen == WacomPen::Touch {
+                state.last_touch_state.store(pen_state, Ordering::Relaxed);
+            }
 
             Some(InputEvent::WacomEvent {
                 event: WacomEvent::InstrumentChange {
                     pen,
-                    state: ev.value() != 0,
+                    state: pen_state,
                 },
             })
         }
@@ -143,16 +146,12 @@ pub fn decode(ev: &EvInputEvent, outer_state: &InputDeviceState) -> Option<Input
                     // the last_dist supplants to that current max.
                     if state.last_pressure.load(Ordering::Relaxed) == 0 {
                         state.last_dist.store(ev.value() as u16, Ordering::Relaxed);
-                        state
-                            .last_tool
-                            .store(Some(WacomPen::ToolPen), Ordering::Relaxed);
+                        state.last_touch_state.store(false, Ordering::Relaxed);
                     } else {
                         state
                             .last_pressure
                             .fetch_add(ev.value() as u16, Ordering::Relaxed);
-                        state
-                            .last_tool
-                            .store(Some(WacomPen::Touch), Ordering::Relaxed);
+                        state.last_touch_state.store(true, Ordering::Relaxed);
                     }
                 }
                 ecodes::ABS_TILT_X => {


### PR DESCRIPTION
This should fix a weird edge-case bug in the event handling code. (Thanks to `okeh` on the discord for finding this issue and helping me debug.)

I've included the commit-message description below, but let me know if anything's not clear. (Or if you know what the "interesting behaviour" in the `ecodes::ABS_DISTANCE` handler is!)

---

Previously, the wacom code would emit WacomEvent::Hover iff the last event seen was ToolPen. This has the wrong behaviour when the pen is leaving the screen, since a Touch event gets emitted as the pen lifts but another ToolPen won't be emitted until the pen is no longer near the screen at all. Instead, we use the current touch state to decide if we're hovering or
not.

So why wasn't this always broken? In the ABS_DIST code farther down in the file, it would update last_tool as part of some pressure / distance corrections I don't fully understand. When we hit this codepath, the resulting last_tool value seems to be correct.  That code seems to reliably fire pretty often on my tablet, masking the bug, but it seems that it's not guaranteed to happen.

Anyways this is all a bit sketchy, and we should probably test on a couple devices before calling it good.