### PR TITLE
Make framebuffer_update public

### DIFF
--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -32,7 +32,7 @@ pub struct Framebuffer {
     /// like it has been done in `Framebuffer::new(..)`.
     pub var_screen_info: VarScreeninfo,
     pub fix_screen_info: FixScreeninfo,
-    pub(crate) framebuffer_update: FramebufferUpdate,
+    pub framebuffer_update: FramebufferUpdate,
 }
 
 unsafe impl Send for Framebuffer {}


### PR DESCRIPTION
I need this variable to be public, since you can't rotate the framebuffer in hardware otherwise (rm 1 only). Thought I could get away with a new instance, but since the new instance re initializes my changed data (and resets the rotation value), it wouldn't work that way.

On the rM 2, I know do this in software (was disabled there until now) but for the rM 1 I prefer to let the hardware do the pixel transformation.

Another solution to this would be to implement [this](https://github.com/LinusCDE/plato/blob/09fd60ef9f45ee3621793bc7e7b8bbbe5a687dea/src/framebuffer/remarkable.rs#L381) as part of a new function to update the fix_screen_info. But I recon nobody except me will ever need this, and it might sound weird to "update fixed info". But I have no problems doing this instead if preferred.