### PR TITLE
Fix submodule URL for Freetype

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "legacy-c-impl/libfreetype"]
 	path = legacy-c-impl/libfreetype
-	url = git://github.com/ricardoquesada/libfreetype
+	url = https://github.com/ricardoquesada/libfreetype


### PR DESCRIPTION
Due to recent [changes in GitHub’s supported protocols](https://github.blog/2021-09-01-improving-git-protocol-security-github/), the fetching of submodules of this repository is failing. This also causes [folly](https://github.com/bkirwi/folly)’s build to fail, since for some reason the submodules are fetched as part of the build (@bkirwi).

This patch simply updates the submodule’s URL to use https:// instead of git://.