### PR TITLE
Prevent usage newer evdev than 0.11.3 due to compilation error for armv7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ image = { version = "0.23.14", optional = true }
 line_drawing = { version = "1.0.0", optional = true }
 
 # input
-evdev = { version = "0.11.3", optional = true }
+evdev = { version = "<=0.11.3", optional = true }
 epoll = { version = "4.3.1", optional = true }
 fxhash = { version = "0.2.1", optional = true }
 


### PR DESCRIPTION
This should fix issue #106 by capping the version of evdev used for now.

I also tested with the newer minor version (0.12.0) and it had the same issue as well.