### PR TITLE
Fix warnings and satisfy clippy

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -5,7 +5,7 @@ use libremarkable::framebuffer::storage;
 use libremarkable::framebuffer::PartialRefreshMode;
 use libremarkable::framebuffer::{FramebufferDraw, FramebufferIO, FramebufferRefresh};
 use libremarkable::image::GenericImage;
-use libremarkable::input::{gpio, multitouch, wacom, InputDevice, InputEvent};
+use libremarkable::input::{InputDevice, InputEvent};
 use libremarkable::ui_extensions::element::{
     UIConstraintRefresh, UIElement, UIElementHandle, UIElementWrapper,
 };

--- a/src/framebuffer/common.rs
+++ b/src/framebuffer/common.rs
@@ -38,7 +38,7 @@ pub const FBIOPUTCMAP: NativeWidthType = 0x4605;
 pub const FBIOPAN_DISPLAY: NativeWidthType = 0x4606;
 pub const FBIO_CURSOR: NativeWidthType = 0x4608;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum color {
     BLACK,
     RED,
@@ -167,7 +167,7 @@ pub const DRAWING_QUANT_BIT: i32 = 0x7614_3b24;
 pub const DRAWING_QUANT_BIT_2: i32 = 0x75e7_bb24;
 pub const DRAWING_QUANT_BIT_3: i32 = 0x5_3ed4;
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[repr(C)]
 pub struct mxcfb_rect {
     pub top: u32,
@@ -288,7 +288,7 @@ impl mxcfb_rect {
     }
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum mxcfb_ioctl {
     MXCFB_NONE = 0x00,
     MXCFB_SET_WAVEFORM_MODES = 0x2B,
@@ -313,7 +313,7 @@ pub enum mxcfb_ioctl {
     MXCFB_ENABLE_EPDC_ACCESS = 0x36,
 }
 
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum auto_update_mode {
     AUTO_UPDATE_MODE_REGION_MODE = 0,
     AUTO_UPDATE_MODE_AUTOMATIC_MODE = 1,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -74,7 +74,7 @@ impl InputDeviceState {
 }
 
 #[repr(u16)]
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum WacomPen {
     /// When the pen gets into the reach of the digitizer
     /// a tool will be selected. This is useful for software
@@ -89,7 +89,7 @@ pub enum WacomPen {
     Stylus2 = ecodes::BTN_STYLUS2,
 }
 
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum WacomEventType {
     InstrumentChange,
     Hover,
@@ -116,7 +116,7 @@ pub enum WacomEvent {
     Unknown,
 }
 
-#[derive(Debug, Copy, Clone, PartialEq)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Finger {
     pub tracking_id: i32,
 
@@ -142,7 +142,7 @@ impl Default for Finger {
     }
 }
 
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum MultitouchEvent {
     Press { finger: Finger },
     Release { finger: Finger },
@@ -161,7 +161,7 @@ impl MultitouchEvent {
     }
 }
 
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum PhysicalButton {
     LEFT,
     MIDDLE,
@@ -170,7 +170,7 @@ pub enum PhysicalButton {
     WAKEUP,
 }
 
-#[derive(PartialEq, Copy, Clone, Debug)]
+#[derive(PartialEq, Eq, Copy, Clone, Debug)]
 pub enum GPIOEvent {
     Press { button: PhysicalButton },
     Unpress { button: PhysicalButton },

--- a/src/ui_extensions/element.rs
+++ b/src/ui_extensions/element.rs
@@ -18,7 +18,7 @@ pub struct ActiveRegionHandler {
     pub element: UIElementHandle,
 }
 
-impl<'a> std::fmt::Debug for ActiveRegionHandler {
+impl std::fmt::Debug for ActiveRegionHandler {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{0:p}", self)
     }


### PR DESCRIPTION
This fixes the failing clippy check in #107 and remove a warning when building the example `demo`.

As with that issue, will merge this in about a day if nobody is against it (cc @bkirwi, @fenollp).