### PR TITLE
Bump evdev and lib versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libremarkable"
-version = "0.6.1"
+version = "0.6.2"
 authors = ["Can Selcik <contact@cselcik.com>"]
 repository = "https://github.com/canselcik/libremarkable"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ image = { version = "0.23.14", optional = true }
 line_drawing = { version = "1.0.0", optional = true }
 
 # input
-evdev = { version = "<=0.11.3", optional = true }
+evdev = { version = "0.12.1", optional = true }
 epoll = { version = "4.3.1", optional = true }
 fxhash = { version = "0.2.1", optional = true }
 


### PR DESCRIPTION
Evdev has gotten a new release which means we can now ship a working release of libremarkable again.

This will bump both the evdev version and the lib version. When merged I'll update the release on crates.io.