### PR TITLE
Fix clippy warnings + uprade some audited deps 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,34 +16,32 @@ jobs:
         components: rustfmt
     - uses: actions-rs/cargo@v1
       with:
-        command: check
-        use-cross: true
-        args: --target ${{ env.TARGET }}
+        command: fetch
     - uses: actions-rs/cargo@v1
       with:
         command: check
         use-cross: true
-        args: --target ${{ env.TARGET }} --no-default-features
+        args: --target ${{ env.TARGET }} --locked --frozen --offline
     - uses: actions-rs/cargo@v1
       with:
         command: check
         use-cross: true
-        args: --target ${{ env.TARGET }} --no-default-features --features input
+        args: --target ${{ env.TARGET }} --locked --frozen --offline --no-default-features --features input
     - uses: actions-rs/cargo@v1
       with:
         command: check
         use-cross: true
-        args: --target ${{ env.TARGET }} --no-default-features --features framebuffer
+        args: --target ${{ env.TARGET }} --locked --frozen --offline --no-default-features --features framebuffer
     - uses: actions-rs/cargo@v1
       with:
         command: check
         use-cross: true
-        args: --target ${{ env.TARGET }} --no-default-features --features framebuffer-text-drawing,input
+        args: --target ${{ env.TARGET }} --locked --frozen --offline --no-default-features --features framebuffer-text-drawing,input
     - uses: actions-rs/cargo@v1
       with:
         command: check
         use-cross: true
-        args: --target ${{ env.TARGET }} --no-default-features --features appctx
+        args: --target ${{ env.TARGET }} --locked --frozen --offline --no-default-features --features appctx
 
   test:
     name: Test Suite on gnueabihf
@@ -61,9 +59,12 @@ jobs:
         components: rustfmt
     - uses: actions-rs/cargo@v1
       with:
+        command: fetch
+    - uses: actions-rs/cargo@v1
+      with:
         command: test
         use-cross: true
-        args: --target ${{ env.TARGET }}
+        args: --target ${{ env.TARGET }} --locked --frozen --offline
   test-local:
     name: Test Suite
     runs-on: ubuntu-latest
@@ -75,7 +76,11 @@ jobs:
         toolchain: stable
     - uses: actions-rs/cargo@v1
       with:
+        command: fetch
+    - uses: actions-rs/cargo@v1
+      with:
         command: test
+        args: --locked --frozen --offline
 
   fmt:
     name: Rustfmt
@@ -89,6 +94,9 @@ jobs:
         target: ${{ env.TARGET }}
         override: true
         components: rustfmt
+    - uses: actions-rs/cargo@v1
+      with:
+        command: fetch
     - uses: actions-rs/cargo@v1
       with:
         command: fmt
@@ -106,6 +114,9 @@ jobs:
         target: ${{ env.TARGET }}
         override: true
         components: rustfmt, clippy
+    - uses: actions-rs/cargo@v1
+      with:
+        command: fetch
     - uses: actions-rs/cargo@v1
       with:
         command: clippy

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,9 @@
 on: [push, pull_request]
 name: Continuous integration
+
+env:
+  TARGET: armv7-unknown-linux-musleabihf
+
 jobs:
 
   check:
@@ -121,7 +125,4 @@ jobs:
       with:
         command: clippy
         use-cross: true
-        args: --target ${{ env.TARGET }} -- -D warnings
-
-env:
-  TARGET: armv7-unknown-linux-musleabihf
+        args: --target ${{ env.TARGET }} --locked --frozen --offline -- -D warnings --no-deps -W clippy::cast_lossless -W clippy::redundant_closure_for_method_calls -W clippy::str_to_string

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 
 [dependencies]
 log = "0.4.14"
-env_logger = "0.9.0"
+env_logger = "0.10.0"
 once_cell = "1.9.0"
 atomic = "0.5.1"
 cgmath = "0.18.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,8 +86,8 @@ crate-type = ["bin"]
 redhook = "2.0.0"
 libc = "0.2.69"
 # For demo
-chrono = "0.4.19"
+chrono = "0.4.26"
 # For live
-tiny_http = "0.9.0"
+tiny_http = "0.12.0"
 # For screenshot
 rgb565 = "0.1.3"

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -487,7 +487,7 @@ fn on_wacom_input(app: &mut appctx::ApplicationContext<'_>, input: input::WacomE
                 mult = 50; // Rough size of the rubber end
             }
 
-            wacom_stack.push_back((position.cast().unwrap(), pressure as i32));
+            wacom_stack.push_back((position.cast().unwrap(), i32::from(pressure)));
 
             while wacom_stack.len() >= 3 {
                 let framebuffer = app.get_framebuffer_ref();

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -493,7 +493,7 @@ fn on_wacom_input(app: &mut appctx::ApplicationContext<'_>, input: input::WacomE
 
             while wacom_stack.len() >= 3 {
                 let framebuffer = app.get_framebuffer_ref();
-                let points = vec![
+                let points = [
                     wacom_stack.pop_front().unwrap(),
                     *wacom_stack.get(0).unwrap(),
                     *wacom_stack.get(1).unwrap(),
@@ -577,7 +577,7 @@ fn on_touch_handler(app: &mut appctx::ApplicationContext<'_>, input: input::Mult
             let rect = match G_TOUCH_MODE.load(Ordering::Relaxed) {
                 TouchMode::Bezier => {
                     let position_float = finger.pos.cast().unwrap();
-                    let points = vec![
+                    let points = [
                         (cgmath::vec2(-40.0, 0.0), 2.5),
                         (cgmath::vec2(40.0, -60.0), 5.5),
                         (cgmath::vec2(0.0, 0.0), 3.5),

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -98,12 +98,14 @@ const CANVAS_REGION: mxcfb_rect = mxcfb_rect {
     width: 1404,
 };
 
+type PointAndPressure = (cgmath::Point2<f32>, i32);
+
 static G_TOUCH_MODE: Lazy<Atomic<TouchMode>> = Lazy::new(|| Atomic::new(TouchMode::OnlyUI));
 static G_DRAW_MODE: Lazy<Atomic<DrawMode>> = Lazy::new(|| Atomic::new(DrawMode::Draw(2)));
 static UNPRESS_OBSERVED: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
 static WACOM_IN_RANGE: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
 static WACOM_RUBBER_SIDE: Lazy<AtomicBool> = Lazy::new(|| AtomicBool::new(false));
-static WACOM_HISTORY: Lazy<Mutex<VecDeque<(cgmath::Point2<f32>, i32)>>> =
+static WACOM_HISTORY: Lazy<Mutex<VecDeque<PointAndPressure>>> =
     Lazy::new(|| Mutex::new(VecDeque::new()));
 static G_COUNTER: Lazy<Mutex<u32>> = Lazy::new(|| Mutex::new(0));
 static SAVED_CANVAS: Lazy<Mutex<Option<storage::CompressedCanvasState>>> =
@@ -371,7 +373,7 @@ fn toggle_touch(app: &mut appctx::ApplicationContext<'_>) {
             border_px: _,
         } = elem.write().inner
         {
-            *text = new_state.to_string();
+            *text = new_state.to_owned();
         }
     }
     app.draw_element("toggleTouch");

--- a/examples/live.rs
+++ b/examples/live.rs
@@ -26,8 +26,8 @@ fn main() {
             .dump_region(framebuffer::common::mxcfb_rect {
                 top: 0,
                 left: 0,
-                width: DISPLAYWIDTH as u32,
-                height: DISPLAYHEIGHT as u32,
+                width: DISPLAYWIDTH.into(),
+                height: DISPLAYHEIGHT.into(),
             })
             .unwrap();
 

--- a/examples/screenshot.rs
+++ b/examples/screenshot.rs
@@ -10,8 +10,8 @@ use rgb565::Rgb565;
 
 fn main() {
     let fb = Framebuffer::new();
-    let width = DISPLAYWIDTH as u32;
-    let height = DISPLAYHEIGHT as u32;
+    let width = u32::from(DISPLAYWIDTH);
+    let height = u32::from(DISPLAYHEIGHT);
     let contents = fb
         .dump_region(mxcfb_rect {
             top: 0,

--- a/examples/swtfb_sysv_spy.rs
+++ b/examples/swtfb_sysv_spy.rs
@@ -28,7 +28,7 @@ hook! {
                 eprintln!("Spy: msgsnd: Message: {{ swt_update.mtype: {:?}, data: ... }}", msg.mtype);
                 let data_str_formatted = match msg.mtype {
                     swtfb_client::MSG_TYPE::INIT_t => {
-                        String::from("...")
+                        "...".to_owned()
                     },
                     swtfb_client::MSG_TYPE::UPDATE_t => {
                         format!("{:?}", msg.data.update)

--- a/src/appctx.rs
+++ b/src/appctx.rs
@@ -304,8 +304,7 @@ impl<'a> ApplicationContext<'a> {
 
     pub fn draw_elements(&mut self) {
         start_bench!(stopwatch, draw_elements);
-        let mut elems: std::vec::Vec<UIElementHandle> =
-            self.ui_elements.values().cloned().collect();
+        let mut elems: Vec<_> = self.ui_elements.values().cloned().collect();
 
         for element in &mut elems {
             let handler = element.read().onclick.map(|handler| ActiveRegionHandler {

--- a/src/framebuffer/common.rs
+++ b/src/framebuffer/common.rs
@@ -98,9 +98,9 @@ impl color {
         //    green   : offset = 5,   length =6,      msb_right = 0
         //    blue    : offset = 0,   length =5,      msb_right = 0
         //
-        let r5 = (r8 as u16 + 1) * 0b11111 / 255;
-        let g6 = (g8 as u16 + 1) * 0b111111 / 255;
-        let b5 = (b8 as u16 + 1) * 0b11111 / 255;
+        let r5 = (u16::from(r8) + 1) * 0b11111 / 255;
+        let g6 = (u16::from(g8) + 1) * 0b111111 / 255;
+        let b5 = (u16::from(b8) + 1) * 0b11111 / 255;
 
         let rgb565 = r5 << 11 | g6 << 5 | b5;
 

--- a/src/framebuffer/draw.rs
+++ b/src/framebuffer/draw.rs
@@ -207,8 +207,8 @@ impl framebuffer::FramebufferDraw for core::Framebuffer {
         mxcfb_rect {
             top: min_y,
             left: min_x,
-            height: (max_y - min_y),
-            width: (max_x - min_x),
+            height: max_y - min_y,
+            width: max_x - min_x,
         }
     }
 

--- a/src/framebuffer/swtfb_client.rs
+++ b/src/framebuffer/swtfb_client.rs
@@ -111,6 +111,7 @@ impl SwtfbClient {
 
     pub fn open_buffer(&self) -> Result<MmapRaw, IoError> {
         let device = OpenOptions::new().read(true).write(true).open(&self.path)?;
+        #[allow(clippy::cast_lossless)]
         let ret = unsafe { libc::ftruncate(device.as_raw_fd(), BUF_SIZE as libc::off_t) };
         if ret < 0 {
             return Err(IoError::last_os_error());

--- a/src/input/ev.rs
+++ b/src/input/ev.rs
@@ -59,7 +59,7 @@ impl EvDevContext {
         match SCANNED.get_device(self.device) {
             Err(e) => error!("Error while reading events from epoll fd: {0}", e),
             Ok(mut dev) => {
-                let mut v = vec![epoll::Event {
+                let mut v = [epoll::Event {
                     events: (epoll::Events::EPOLLET
                         | epoll::Events::EPOLLIN
                         | epoll::Events::EPOLLPRI)

--- a/src/input/multitouch.rs
+++ b/src/input/multitouch.rs
@@ -43,11 +43,10 @@ pub fn decode(ev: &EvInputEvent, outer_state: &InputDeviceState) -> Vec<InputEve
             match ev.code() {
                 ecodes::SYN_REPORT => {
                     let mut events: Vec<InputEvent> = vec![];
-                    for (_slot, mut finger) in fingers.iter_mut() {
+                    for (_slot, finger) in fingers.iter_mut() {
                         if !finger.last_pressed && finger.pressed {
                             // Pressed
                             finger.last_pressed = finger.pressed;
-
                             events.push(InputEvent::MultitouchEvent {
                                 event: MultitouchEvent::Press { finger: *finger },
                             });

--- a/src/input/multitouch.rs
+++ b/src/input/multitouch.rs
@@ -14,8 +14,8 @@ use std::sync::{
     Mutex,
 };
 
-static MT_HSCALAR: Lazy<f32> = Lazy::new(|| (DISPLAYWIDTH as f32) / (*MTWIDTH as f32));
-static MT_VSCALAR: Lazy<f32> = Lazy::new(|| (DISPLAYHEIGHT as f32) / (*MTHEIGHT as f32));
+static MT_HSCALAR: Lazy<f32> = Lazy::new(|| f32::from(DISPLAYWIDTH) / f32::from(*MTWIDTH));
+static MT_VSCALAR: Lazy<f32> = Lazy::new(|| f32::from(DISPLAYHEIGHT) / f32::from(*MTHEIGHT));
 
 pub struct MultitouchState {
     fingers: Mutex<FxHashMap<i32 /* slot */, Finger>>,

--- a/src/input/wacom.rs
+++ b/src/input/wacom.rs
@@ -12,8 +12,8 @@ use std::sync::atomic::{AtomicU16, Ordering};
 use crate::cgmath;
 use crate::dimensions::{DISPLAYHEIGHT, DISPLAYWIDTH, WACOMHEIGHT, WACOMWIDTH};
 
-static WACOM_HSCALAR: Lazy<f32> = Lazy::new(|| (DISPLAYWIDTH as f32) / (*WACOMWIDTH as f32));
-static WACOM_VSCALAR: Lazy<f32> = Lazy::new(|| (DISPLAYHEIGHT as f32) / (*WACOMHEIGHT as f32));
+static WACOM_HSCALAR: Lazy<f32> = Lazy::new(|| f32::from(DISPLAYWIDTH) / f32::from(*WACOMWIDTH));
+static WACOM_VSCALAR: Lazy<f32> = Lazy::new(|| f32::from(DISPLAYHEIGHT) / f32::from(*WACOMHEIGHT));
 
 pub struct WacomState {
     last_x: AtomicU16,


### PR DESCRIPTION
Note: some audited deps are not simple to upgrade (and weren't). This needs further work:
```
λ cargo audit
    Fetching advisory database from `https://github.com/RustSec/advisory-db.git`
      Loaded 561 security advisories (from /home/pete/.cargo/advisory-db)
    Updating crates.io index
    Scanning Cargo.lock for vulnerabilities (134 crate dependencies)
Crate:     rustc-serialize
Version:   0.3.24
Title:     Stack overflow in rustc_serialize when parsing deeply nested JSON
Date:      2022-01-01
ID:        RUSTSEC-2022-0004
URL:       https://rustsec.org/advisories/RUSTSEC-2022-0004
Solution:  No fixed upgrade is available!
Dependency tree:
rustc-serialize 0.3.24
├── num-rational 0.1.42
│   └── num 0.1.42
│       └── stopwatch 0.0.7
│           └── libremarkable 0.6.0
├── num-complex 0.1.43
│   └── num 0.1.42
└── num-bigint 0.1.44
    ├── num-rational 0.1.42
    └── num 0.1.42

Crate:     time
Version:   0.1.45
Title:     Potential segfault in the time crate
Date:      2020-11-18
ID:        RUSTSEC-2020-0071
URL:       https://rustsec.org/advisories/RUSTSEC-2020-0071
Severity:  6.2 (medium)
Solution:  Upgrade to >=0.2.23
Dependency tree:
time 0.1.45
└── chrono 0.4.26
    └── libremarkable 0.6.0

Crate:     rusttype
Version:   0.9.3
Warning:   unmaintained
Title:     rusttype is Unmaintained
Date:      2021-04-01
ID:        RUSTSEC-2021-0140
URL:       https://rustsec.org/advisories/RUSTSEC-2021-0140
Dependency tree:
rusttype 0.9.3
└── libremarkable 0.6.0

error: 2 vulnerabilities found!
warning: 1 allowed warning found
```

Also: shouldn't we be setting dependency versions with broader constraints than an exact version number? e.g: `"1.0"` or `"1"`? Lib consumers then should be able to upgrade their own deps before eventually making PRs against this repo