### PR TITLE
reduce required dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libremarkable"
-version = "0.6.2"
+version = "0.7.0"
 authors = ["Can Selcik <contact@cselcik.com>"]
 repository = "https://github.com/canselcik/libremarkable"
 license = "MIT"
@@ -11,7 +11,6 @@ edition = "2021"
 
 [dependencies]
 log = "0.4.14"
-env_logger = "0.10.0"
 once_cell = "1.9.0"
 atomic = "0.5.1"
 cgmath = "0.18.0"
@@ -54,7 +53,7 @@ framebuffer-text-drawing = ["framebuffer-drawing", "rusttype"]
 input-types = []
 input = ["scan", "input-types", "evdev", "epoll", "fxhash"]
 battery = []
-appctx = ["framebuffer-text-drawing", "image", "input", "aabb-quadtree"]
+appctx = ["framebuffer-text-drawing", "input", "aabb-quadtree"]
 
 enable-runtime-benchmarking = ["stopwatch"]
 
@@ -82,6 +81,7 @@ path = "examples/live.rs"
 crate-type = ["bin"]
 
 [dev-dependencies]
+env_logger = "0.10.0"
 # For spy
 redhook = "2.0.0"
 libc = "0.2.69"

--- a/src/appctx.rs
+++ b/src/appctx.rs
@@ -230,6 +230,7 @@ impl<'a> ApplicationContext<'a> {
         draw_area
     }
 
+    #[cfg(feature = "image")]
     pub fn display_image(
         &mut self,
         img: &image::DynamicImage,

--- a/src/ui_extensions/element.rs
+++ b/src/ui_extensions/element.rs
@@ -79,6 +79,7 @@ pub enum UIElement {
         foreground: color,
         border_px: u32,
     },
+    #[cfg(feature = "image")]
     Image {
         img: image::DynamicImage,
     },
@@ -158,6 +159,7 @@ impl UIElementWrapper {
                 text,
                 refresh,
             ),
+            #[cfg(feature = "image")]
             UIElement::Image { ref img } => {
                 app.display_image(img, self.position.cast().unwrap(), refresh)
             }

--- a/src/ui_extensions/element.rs
+++ b/src/ui_extensions/element.rs
@@ -80,9 +80,7 @@ pub enum UIElement {
         border_px: u32,
     },
     #[cfg(feature = "image")]
-    Image {
-        img: image::DynamicImage,
-    },
+    Image { img: image::DynamicImage },
     Region {
         size: cgmath::Vector2<u32>,
         border_color: color,


### PR DESCRIPTION
- move env_logger to dev-dependencies (was only used in the examples)
- move image functions behind existing feature flag

I bumped the version to 0.7.0 as this could be a breaking change for someone having appctx but not image enabled.

The motivation was to flatten the dependency tree, reduce build time and reduce target folder size.