### PR TITLE
Allow disabling the automatic use of our internal swtfb client by setting an env

### DIFF
--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -50,7 +50,16 @@ impl Framebuffer {
         let device = &*device::CURRENT_DEVICE;
         match device.model {
             Model::Gen1 => Framebuffer::device(device.get_framebuffer_path()),
-            Model::Gen2 => Framebuffer::rm2fb(device.get_framebuffer_path()),
+            Model::Gen2 => {
+                // Auto-select old method still if env LIBREMARKABLE_FB_DISFAVOR_INTERNAL_RM2FB is set affirmatively
+                if let Ok(env_answer) = std::env::var("LIBREMARKABLE_FB_DISFAVOR_INTERNAL_RM2FB") {
+                    let env_answer = env_answer.to_lowercase();
+                    if env_answer == "1" || env_answer == "true" || env_answer == "yes" {
+                        Framebuffer::device(device.get_framebuffer_path())
+                    }
+                }
+                Framebuffer::rm2fb(device.get_framebuffer_path())
+            }
         }
     }
 


### PR DESCRIPTION
There was an issue raised at #117 where presumably a new library is used as a shim for rM 2 Framebuffer support, but it doesn't seem to use the offical server, which our client relies on.

In general there had been issues raised that issues could arise even with the official shim if it gets updated but our implementation still does the old behaviour. Such applications would require to be recompiled to use `Framebuffer::device` instead of `Framebuffer::new` or otherwise not work.

This PR allows people to make libremarkable choose the old implementation in case the developer didn't care about it anyway / left the choice up to libremarkable.

It is done by setting the lengthy env `LIBREMARKABLE_FB_DISFAVOR_INTERNAL_RM2FB` to `1`, `yes` or `true` (case-insensitive). Feel free to suggest a better name, I couldn't think of any.

Package maintainers could also fix arising issues by setting that env in some wrapper script for that binary without the need of any source code change or even re-complication if the binary is recent enough.

Basically this should future proof applications built using libremarkable better.