### PR TITLE
Fixed Crashing Due To Unknown Pen Inputs

### DIFF
--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -548,7 +548,7 @@ fn on_wacom_input(app: &mut appctx::ApplicationContext<'_>, input: input::WacomE
                         wacom_stack.clear();
                     }
                 }
-                _ => {},
+                _ => {}
             }
         }
         input::WacomEvent::Hover {

--- a/examples/demo.rs
+++ b/examples/demo.rs
@@ -548,7 +548,7 @@ fn on_wacom_input(app: &mut appctx::ApplicationContext<'_>, input: input::WacomE
                         wacom_stack.clear();
                     }
                 }
-                _ => unreachable!(),
+                _ => {},
             }
         }
         input::WacomEvent::Hover {


### PR DESCRIPTION
Unanticipated inputs from the Wacom Pen will cause the code to reach unreachable causing the entire app to crash. This includes any side buttons on 3rd party pens