### PR TITLE
Fix a couple recent regressions

### DIFF
--- a/src/framebuffer/core.rs
+++ b/src/framebuffer/core.rs
@@ -53,7 +53,7 @@ impl Framebuffer {
             Model::Gen2 => {
                 // Auto-select old method still if env LIBREMARKABLE_FB_DISFAVOR_INTERNAL_RM2FB is set affirmatively
                 match std::env::var("LIBREMARKABLE_FB_DISFAVOR_INTERNAL_RM2FB").as_deref() {
-                    Ok("1") => Framebuffer::device(device.get_framebuffer_path()),
+                    Ok("1") => Framebuffer::device(Model::Gen1.framebuffer_path()),
                     _ => Framebuffer::rm2fb(device.get_framebuffer_path()),
                 }
             }

--- a/src/framebuffer/draw.rs
+++ b/src/framebuffer/draw.rs
@@ -191,16 +191,13 @@ impl framebuffer::FramebufferDraw for core::Framebuffer {
                 }
 
                 glyph.draw(|x, y, v| {
+                    let mult = (1.0 - v).min(1.0);
                     self.write_pixel(
                         Point2 {
                             x: (x + bounding_box.min.x as u32) as i32,
                             y: (y + bounding_box.min.y as u32) as i32,
                         },
-                        color::RGB(
-                            (255.0 + (c1 - 255.0) * v) as u8,
-                            (255.0 + (c2 - 255.0) * v) as u8,
-                            (255.0 + (c3 - 255.0) * v) as u8,
-                        ),
+                        color::RGB((c1 * mult) as u8, (c2 * mult) as u8, (c3 * mult) as u8),
                     )
                 });
             }


### PR DESCRIPTION
First: when we added an env var recently to allow forcing a fallback to the rm1 framebuffer interface, we were still using the rm2 path. This path does exist, but attempting ioctls on it will fail. Fixed by specifying the old path when setting the env var.

Second: this recent font rendering change broke the demo app! I didn't look into it, but for now let's just get main back in a good state. It's a small diff.